### PR TITLE
Fix Claude login to use setup-token

### DIFF
--- a/openbase_coder_cli/claude_auth.py
+++ b/openbase_coder_cli/claude_auth.py
@@ -111,11 +111,7 @@ def run_claude_login(
     email: str | None = None,
 ) -> int:
     command = claude_command or shutil.which("claude") or "claude"
-    args = [command, "auth", "login", "--claudeai"]
-    if sso:
-        args.append("--sso")
-    if email:
-        args.extend(["--email", email])
+    args = [command, "setup-token"]
     return subprocess.call(args, env=claude_env(config_dir))
 
 


### PR DESCRIPTION
## Summary
- The Claude CLI removed the `auth login --claudeai` subcommand; `setup-token` is the replacement
- Updates `run_claude_login` in `claude_auth.py` to call `claude setup-token` instead of the defunct `claude auth login --claudeai`

## Test plan
- [ ] Run `openbase-coder claude login` and verify it launches `claude setup-token` without errors
- [ ] Run `openbase-coder setup` and confirm the Claude auth step no longer fails with `unknown option '--claudeai'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)