### PR TITLE
Fix announcer TTS to use streaming synthesis for Openbase Cloud

### DIFF
--- a/openbase_coder_cli/livekit_agent/livekit.py
+++ b/openbase_coder_cli/livekit_agent/livekit.py
@@ -2193,12 +2193,22 @@ class AnnouncerSpeechQueue:
         *,
         voice_id: str | None,
     ) -> AsyncIterator[rtc.AudioFrame]:
-        async with self._announcer_tts.synthesize_with_voice(
-            text,
-            voice_id=voice_id,
-        ) as stream:
-            async for event in stream:
+        # Use streaming synthesis (WebSocket) instead of non-streaming
+        # synthesize() (HTTP POST to /tts/bytes) because the Openbase Cloud
+        # audio proxy only supports the WebSocket path.
+        resolved_voice_id = self._announcer_tts.resolve_voice_id(voice_id)
+        tts_stream = self._announcer_tts._tts_for_voice(resolved_voice_id).stream()
+        spoken_text = format_for_speech(text)
+        if not spoken_text:
+            spoken_text = "Technical output omitted, shown on screen."
+        tts_stream.push_text(spoken_text)
+        tts_stream.flush()
+        tts_stream.end_input()
+        try:
+            async for event in tts_stream:
                 yield event.frame
+        finally:
+            await tts_stream.aclose()
 
     async def _play_audio(self, message: AnnouncerAudioMessage) -> None:
         started = time.monotonic()


### PR DESCRIPTION
## Summary
- The announcer TTS was using non-streaming `synthesize()` (HTTP POST to `/tts/bytes`), which the Openbase Cloud audio proxy does not support (returns 403 Forbidden)
- Switched `_announcer_audio` to use the streaming WebSocket path (`stream()` + `push_text()` + `flush()` + `end_input()`), matching the approach used by the direct voice which works correctly through the proxy
- This fixes super agent announcements (e.g. Caroline's intro) being silent when using `openbase_cloud` as the TTS provider

## Test plan
- [ ] Start a LiveKit voice session with `tts_provider: "openbase_cloud"` in dispatcher config
- [ ] Trigger a super agent announcement (e.g. thread introduction)
- [ ] Verify audio plays through the voice call without 403 errors in livekit-agent logs