### PR TITLE
feat: onboarding heartbeat, deregister, and identity-aware Tailscale registration

### DIFF
--- a/openbase_coder_cli/cli/onboarding.py
+++ b/openbase_coder_cli/cli/onboarding.py
@@ -6,8 +6,13 @@ import json
 
 import click
 
-from openbase_coder_cli.services.cloud_registration import register_and_report
+from openbase_coder_cli.services.cloud_registration import (
+    deregister_device_with_cloud,
+    register_and_report,
+    register_device_with_cloud,
+)
 from openbase_coder_cli.services.onboarding import onboarding_status_payload
+from openbase_coder_cli.services.tailscale_serve import tailscale_up
 
 
 @click.group()
@@ -66,6 +71,19 @@ def onboarding_report_cmd() -> None:
     """Register this device and report CLI state to openbase-cloud."""
     result = register_and_report()
     if result.ok:
+        if not result.tailscale_advertised:
+            # Registered, but Tailscale is not connected so no address was
+            # shared — pairing cannot complete. Signal a non-zero exit so the
+            # desktop app shows guidance instead of a false "done".
+            click.echo(
+                click.style(
+                    "Registered, but Tailscale isn't connected — no address was "
+                    "shared, so pairing can't complete. Open Tailscale and sign "
+                    "in, then run this again.",
+                    fg="yellow",
+                )
+            )
+            raise SystemExit(2)
         click.echo("Registered device and reported CLI state to openbase-cloud.")
         return
     if not result.supported:
@@ -77,3 +95,43 @@ def onboarding_report_cmd() -> None:
         )
         return
     raise click.ClickException(result.error or "Cloud report failed.")
+
+
+@onboarding.command("heartbeat")
+def onboarding_heartbeat_cmd() -> None:
+    """Re-register this device so it stays "present" in the rendezvous registry.
+
+    Best-effort and quiet: intended to run on a timer while an onboarding page
+    is open. Never fails the caller.
+    """
+    result = register_device_with_cloud()
+    if result.ok:
+        click.echo("heartbeat ok")
+    else:
+        click.echo(click.style(f"heartbeat skipped: {result.error}", fg="yellow"))
+
+
+@onboarding.command("deregister")
+@click.option(
+    "--device-id",
+    "device_id",
+    default=None,
+    help="Device id to forget. Defaults to this machine's own device id.",
+)
+def onboarding_deregister_cmd(device_id: str | None) -> None:
+    """Remove a device from openbase-cloud's rendezvous registry."""
+    result = deregister_device_with_cloud(device_id)
+    if result.ok:
+        click.echo("Deregistered device from openbase-cloud.")
+        return
+    if not result.supported:
+        click.echo(click.style(f"Skipped: {result.error}", fg="yellow"))
+        return
+    raise click.ClickException(result.error or "Cloud deregister failed.")
+
+
+@onboarding.command("tailscale-up")
+def onboarding_tailscale_up_cmd() -> None:
+    """Bring Tailscale online on this Mac, opening browser SSO if needed."""
+    tailscale_up()
+    click.echo("Tailscale is connected.")

--- a/openbase_coder_cli/services/cloud_registration.py
+++ b/openbase_coder_cli/services/cloud_registration.py
@@ -13,7 +13,7 @@ import platform
 import socket
 import time
 import uuid
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from typing import Any
 
 import httpx
@@ -34,6 +34,7 @@ from openbase_coder_cli.services.tailnet_devices import tailscale_self_identity
 from openbase_coder_cli.services.tailscale_serve import tailscale_serve_health
 
 DEVICE_REGISTER_PATH = "/api/openbase/devices/register/"
+DEVICE_DEREGISTER_PATH = "/api/openbase/devices/deregister/"
 REQUEST_TIMEOUT_SECONDS = 15
 
 
@@ -44,9 +45,22 @@ class CloudReportResult:
     error: str | None = None
     status_code: int | None = None
     response: dict[str, Any] | None = None
+    # Whether this registration advertised a Tailscale identity. A registration
+    # can succeed (HTTP 200) while Tailscale is disconnected, in which case the
+    # device is registered without an address and pairing cannot complete —
+    # callers surface this so the user isn't told "done" when it isn't.
+    tailscale_advertised: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+def _payload_advertises_tailscale(payload: dict[str, Any]) -> bool:
+    return bool(
+        payload.get("tailscale_magic_dns")
+        or payload.get("tailscale_ip")
+        or payload.get("tailscale")
+    )
 
 
 def device_registration_payload() -> dict[str, Any]:
@@ -107,12 +121,31 @@ def _with_capabilities(
 
 
 def register_device_with_cloud() -> CloudReportResult:
-    """POST this device's identity to openbase-cloud. Never raises."""
-    result = _post_to_cloud(DEVICE_REGISTER_PATH, device_registration_payload())
+    """POST this device's identity to openbase-cloud. Never raises.
+
+    Lightweight: no Tailscale-serve health probe, so it is cheap enough to run
+    on a heartbeat while an onboarding page is open.
+    """
+    payload = device_registration_payload()
+    result = replace(
+        _post_to_cloud(DEVICE_REGISTER_PATH, payload),
+        tailscale_advertised=_payload_advertises_tailscale(payload),
+    )
     write_onboarding_cache(
         {"last_register": {"at": _timestamp(), **result.to_dict()}}
     )
     return result
+
+
+def deregister_device_with_cloud(device_id: str | None = None) -> CloudReportResult:
+    """Remove a device from openbase-cloud's rendezvous registry. Never raises.
+
+    Defaults to this machine's own device id; pass an explicit id to forget a
+    sibling device (e.g. a stale phone) from the Mac.
+    """
+    return _post_to_cloud(
+        DEVICE_DEREGISTER_PATH, {"device_id": device_id or _device_id()}
+    )
 
 
 def report_cli_state(
@@ -133,9 +166,9 @@ def report_cli_state(
             "tailscale_serve_healthy": serve_healthy,
         },
     )
-    result = _post_to_cloud(
-        DEVICE_REGISTER_PATH,
-        payload,
+    result = replace(
+        _post_to_cloud(DEVICE_REGISTER_PATH, payload),
+        tailscale_advertised=_payload_advertises_tailscale(payload),
     )
     cache_update: dict[str, Any] = {
         "last_report": {

--- a/openbase_coder_cli/services/tailscale_serve.py
+++ b/openbase_coder_cli/services/tailscale_serve.py
@@ -74,6 +74,23 @@ def configure_tailscale_serve() -> None:
     )
 
 
+def tailscale_up() -> None:
+    """Run ``tailscale up`` to bring this node online, opening SSO if needed.
+
+    Returns once the node is authenticated (or immediately if it already was).
+    Output is inherited rather than captured so the login URL reaches the caller,
+    and there is no short timeout since completing SSO is a manual step.
+    """
+    tailscale_bin = _tailscale_bin()
+    if not tailscale_bin:
+        raise RuntimeError(
+            "tailscale was not found (checked PATH and /Applications/Tailscale.app)."
+        )
+    result = subprocess.run([tailscale_bin, "up"], text=True)  # noqa: S603
+    if result.returncode != 0:
+        raise RuntimeError("tailscale up failed. Open Tailscale and sign in, then retry.")
+
+
 def tailscale_serve_health() -> TailscaleServeHealth:
     tailscale_bin = _tailscale_bin()
     if not tailscale_bin:

--- a/tests/test_onboarding_cli.py
+++ b/tests/test_onboarding_cli.py
@@ -70,13 +70,78 @@ def test_onboarding_report_success(monkeypatch) -> None:
     monkeypatch.setattr(
         onboarding_cli,
         "register_and_report",
-        lambda: CloudReportResult(ok=True, supported=True, status_code=200),
+        lambda: CloudReportResult(
+            ok=True, supported=True, status_code=200, tailscale_advertised=True
+        ),
     )
 
     result = CliRunner().invoke(main, ["onboarding", "report"])
 
     assert result.exit_code == 0
     assert "Registered device" in result.output
+
+
+def test_onboarding_report_warns_when_tailscale_not_advertised(monkeypatch) -> None:
+    monkeypatch.setattr(
+        onboarding_cli,
+        "register_and_report",
+        lambda: CloudReportResult(
+            ok=True, supported=True, status_code=200, tailscale_advertised=False
+        ),
+    )
+
+    result = CliRunner().invoke(main, ["onboarding", "report"])
+
+    assert result.exit_code != 0
+    assert "Tailscale isn't connected" in result.output
+
+
+def test_onboarding_heartbeat_ok(monkeypatch) -> None:
+    monkeypatch.setattr(
+        onboarding_cli,
+        "register_device_with_cloud",
+        lambda: CloudReportResult(ok=True, supported=True, status_code=200),
+    )
+
+    result = CliRunner().invoke(main, ["onboarding", "heartbeat"])
+
+    assert result.exit_code == 0
+    assert "heartbeat ok" in result.output
+
+
+def test_onboarding_deregister_success(monkeypatch) -> None:
+    captured = {}
+
+    def fake_deregister(device_id=None):
+        captured["device_id"] = device_id
+        return CloudReportResult(ok=True, supported=True, status_code=200)
+
+    monkeypatch.setattr(
+        onboarding_cli, "deregister_device_with_cloud", fake_deregister
+    )
+
+    result = CliRunner().invoke(
+        main, ["onboarding", "deregister", "--device-id", "mobile-abc"]
+    )
+
+    assert result.exit_code == 0
+    assert "Deregistered device" in result.output
+    assert captured["device_id"] == "mobile-abc"
+
+
+def test_onboarding_tailscale_up_invokes_helper(monkeypatch) -> None:
+    called = {"n": 0}
+
+    def fake_up():
+        called["n"] += 1
+
+    monkeypatch.setattr(onboarding_cli, "tailscale_up", fake_up)
+
+    result = CliRunner().invoke(main, ["onboarding", "tailscale-up"])
+
+    assert result.exit_code == 0
+    assert called["n"] == 1
+    assert "Tailscale is connected" in result.output
 
 
 def test_onboarding_report_skips_when_unsupported(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
CLI-side support for the self-healing onboarding rendezvous and the desktop's live Tailscale pairing flow.

- **`onboarding heartbeat`** — lightweight re-register (no serve-health probe) so a device stays inside the server's freshness window while an onboarding page is open. Stops on uninstall/quit, letting stale rows drop out.
- **`onboarding deregister --device-id`** — remove a device from the rendezvous registry (this machine by default, or a stale phone by id).
- **`onboarding tailscale-up`** — bring Tailscale online, opening browser SSO.
- **Identity-aware `onboarding report`** — threads `tailscale_advertised` through `CloudReportResult`; when registration succeeded but advertised no Tailscale address (Tailscale not connected), it now prints a warning and exits non-zero instead of a silent success.

## Testing
- `uv run pytest tests/test_onboarding_cli.py` → 14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)