### PR TITLE
Make bundled console script shebangs relocatable

### DIFF
--- a/scripts/build_standalone_package.py
+++ b/scripts/build_standalone_package.py
@@ -59,6 +59,7 @@ def main() -> int:
     python_dir = package_dir / "python"
     create_runtime_python(python_dir, args.python)
     install_cli_package(python_dir)
+    relocate_console_scripts(python_dir)
     relocate_macos_python(python_dir)
     stage_bin(
         package_dir,
@@ -148,6 +149,42 @@ def install_cli_package(python_dir: Path) -> None:
         check=True,
         env=_runtime_pip_env(),
     )
+
+
+def relocate_console_scripts(python_dir: Path) -> None:
+    """Rewrite pip's absolute shebangs into relocatable ``/bin/sh`` wrappers.
+
+    pip stamps each console script with the absolute path of the interpreter
+    that installed it, which during a release build is the build-time package
+    directory (``$RUNNER_TEMP/openbase-coder-package-<target>``). That path
+    does not exist once the archive is extracted on a user's machine, so every
+    console script dies with ``bad interpreter``.
+
+    The install prefix is not knowable at build time, so the shebang cannot be
+    rewritten to it. Instead emit the same relocatable wrapper that the bundled
+    interpreter already uses for its own scripts (pip, pydoc3, idle3), which
+    resolves the interpreter relative to the script's own location.
+    """
+    bin_dir = python_dir / "bin"
+    build_shebangs = {
+        f"#!{bin_dir / name}" for name in ("python", "python3", "python3.12")
+    }
+    wrapper = (
+        "#!/bin/sh\n"
+        "'''exec' \"$(dirname -- \"$(realpath -- \"$0\")\")/python3\" \"$0\" \"$@\"\n"
+        "' '''\n"
+    )
+    for path in sorted(bin_dir.iterdir()):
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        shebang, newline, body = text.partition("\n")
+        if not newline or shebang not in build_shebangs:
+            continue
+        path.write_text(wrapper + body, encoding="utf-8")
 
 
 def relocate_macos_python(python_dir: Path) -> None:
@@ -281,6 +318,7 @@ def validate_package(package_dir: Path, version: str) -> None:
             raise RuntimeError(f"Package validation failed; missing {path}")
     _validate_no_external_python_links(package_dir)
     _validate_no_host_macos_library_links(package_dir)
+    _validate_no_build_path_shebangs(package_dir)
     result = subprocess.run(
         [str(package_dir / "bin" / "openbase-coder"), "--version"],
         check=True,
@@ -343,6 +381,32 @@ def _uv_managed_python(version: str) -> Path | None:
         return None
     path = Path(result.stdout.strip())
     return path if path.is_file() else None
+
+
+def _validate_no_build_path_shebangs(package_dir: Path) -> None:
+    """Fail the build if any script hardcodes the build-time package directory.
+
+    ``bin/openbase-coder`` is a hand-written relocatable launcher, so the CLI
+    smoke test in validate_package() passes even when every pip-generated
+    console script in python/bin is broken. Check them directly.
+    """
+    for path in sorted((package_dir / "python" / "bin").iterdir()):
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        if not text.startswith("#!"):
+            continue
+        # Check the exec line too: the sh-wrapper form pip emits for paths
+        # containing spaces keeps the absolute interpreter path on line 2.
+        for line in text.split("\n", 2)[:2]:
+            if str(package_dir) in line:
+                raise RuntimeError(
+                    "Package validation failed; script has a non-relocatable "
+                    f"build-path reference: {path} -> {line.strip()}"
+                )
 
 
 def _validate_no_external_python_links(package_dir: Path) -> None:


### PR DESCRIPTION
## Problem

Every pip-generated console script in the standalone release ships with a GitHub Actions runner path as its shebang:

```
#!/Users/runner/work/_temp/openbase-coder-package-aarch64-apple-darwin/python/bin/python
```

That path does not exist on a user's machine, so the scripts fail with `bad interpreter` (at `execve`, as `ENOENT`). **36 scripts** are affected in the installed `0.10.0-aarch64-apple-darwin` build, including `super-agents-mcp`, `super-agents-backend`, and `gunicorn`. A broken `super-agents-mcp` means the Super Agents MCP server cannot start at all — it is launched by absolute path from `.claude.json`.

## Root cause

There is no temp-prefix-then-relocate step to repair. `release-standalone.yml` builds **directly into the final layout** at a build-time path:

```
package_dir="$RUNNER_TEMP/openbase-coder-package-${target}"
```

`install_cli_package()` then runs `<package_dir>/python/bin/python -m pip install …`, and pip stamps each console script with the absolute path of the interpreter that ran it. The tree is later archived and extracted to `~/.openbase/packages/standalone/releases/<version>-<target>/`, and the baked path dies.

So `--python` cannot help — at build time the interpreter genuinely *is* at that path. And the shebang cannot be rewritten to the install prefix, which is version- and user-specific and unknowable at build time.

`relocate_macos_python()` already exists but only rewrites Mach-O `install_name`/dylib links; it never touches text shebangs.

## Fix

Add `relocate_console_scripts()`, run right after `install_cli_package()`. It rewrites build-time shebangs into the **same relocatable wrapper the bundled interpreter already uses for its own scripts** (`pip`, `pydoc3`, `idle3`), resolving the interpreter relative to the script's own location:

```sh
#!/bin/sh
'''exec' "$(dirname -- "$(realpath -- "$0")")/python3" "$0" "$@"
' '''
```

Script bodies are unchanged, so this is a line-1 swap. Symlinks and native binaries are skipped, and the pass is idempotent.

## Why CI never caught it

`validate_package()`'s only runtime check execs `bin/openbase-coder` — a hand-written relocatable `/bin/sh` launcher from `stage_bin()` that never goes through a pip console script. It passes even when all 36 scripts are broken.

This PR adds `_validate_no_build_path_shebangs()` so a build-time path baked anywhere into `python/bin` fails the release build. It checks the first two lines, since the sh-wrapper form pip emits for paths containing spaces keeps the absolute interpreter path on line 2.

## Verification

Reproduced against a replica package: an unfixed script fails with `ENOENT` after the directory moves; after `relocate_console_scripts()` the same script runs correctly from the new location. Also asserted that native binaries are not corrupted, symlinks are not clobbered, the pass is idempotent, and the new guard rejects both shebang forms then passes on a relocated package. `ruff check`: clean.

## Follow-up (not in this PR)

`stage_bin()` writes the launcher as `python -m openbase_coder_cli.cli`. `python -m` prepends the cwd to `sys.path`, so running `openbase-coder` from inside a checkout of this repo shadows the installed package and crashes with `ModuleNotFoundError: No module named 'openbase_coder_cli._version'`. Adding `-P` (or `PYTHONSAFEPATH=1`) fixes it. Happy to send that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)