### PR TITLE
Add restart dependent planning

### DIFF
--- a/openbase_coder_cli/cli/restart.py
+++ b/openbase_coder_cli/cli/restart.py
@@ -14,7 +14,7 @@ from openbase_coder_cli.services.restart import (
 @click.option(
     "--service",
     type=click.Choice(restart_target_names()),
-    help="Restart exactly one Openbase-managed service.",
+    help="Restart one Openbase-managed service and required dependents.",
 )
 @click.option(
     "--delay",
@@ -38,7 +38,8 @@ def restart(service: str | None, delay: float, recreate_dispatcher: bool) -> Non
     plan = schedule_restart(request)
 
     if service:
-        click.echo(f"Scheduled restart for {service} in {plan.delay_seconds:g}s.")
+        service_list = ", ".join(plan.services)
+        click.echo(f"Scheduled restart for {service_list} in {plan.delay_seconds:g}s.")
     else:
         click.echo(
             f"Scheduled restart for all Openbase-managed services in {plan.delay_seconds:g}s."

--- a/openbase_coder_cli/services/definitions.py
+++ b/openbase_coder_cli/services/definitions.py
@@ -17,6 +17,8 @@ class ServiceDefinition:
     cleanup_command_substrings: tuple[str, ...] = ()
     # Coding backends this service applies to; None means all backends.
     backends: tuple[str, ...] | None = None
+    # Services that must be restarted after this service restarts.
+    restart_dependents: tuple[str, ...] = ()
 
     def supports_backend(self, coding_backend: str) -> bool:
         return self.backends is None or coding_backend in self.backends
@@ -100,6 +102,7 @@ SERVICES: list[ServiceDefinition] = [
         port=7880,
         cleanup_ports=(7880, 7881),
         cleanup_command_substrings=("livekit-server",),
+        restart_dependents=("livekit-agent",),
     ),
     ServiceDefinition(
         name="codex-app-server",

--- a/openbase_coder_cli/services/restart.py
+++ b/openbase_coder_cli/services/restart.py
@@ -60,9 +60,7 @@ def build_restart_plan(request: RestartRequest) -> RestartPlan:
             f"Unknown restart target '{unknown[0]}'. Valid: {valid}"
         )
 
-    services: list[str] = []
-    for target in requested_targets:
-        _append_unique(services, target)
+    services = _expand_restart_targets(requested_targets)
 
     if request.recreate_dispatcher:
         _append_unique(services, "livekit-agent")
@@ -116,7 +114,7 @@ def execute_restart_plan(plan: RestartPlan) -> None:
         prepare_livekit_dispatcher_recreation()
 
     services = [find_service(name) for name in plan.services]
-    for service in services:
+    for service in reversed(services):
         if launchctl_status(service)["installed"]:
             launchctl_bootout(service)
 
@@ -167,3 +165,34 @@ def _scheduled_restart_command(plan: RestartPlan) -> str:
 def _append_unique(items: list[str], item: str) -> None:
     if item not in items:
         items.append(item)
+
+
+def _expand_restart_targets(requested_targets: list[str]) -> list[str]:
+    services: list[str] = []
+    visiting: set[str] = set()
+    visited: set[str] = set()
+    definitions = {service.name: service for service in SERVICES}
+
+    def visit(name: str) -> None:
+        if name in visited:
+            return
+        if name in visiting:
+            raise click.ClickException(
+                f"Restart dependency cycle detected at '{name}'."
+            )
+        visiting.add(name)
+        _append_unique(services, name)
+        for dependent_name in definitions[name].restart_dependents:
+            if dependent_name not in definitions:
+                raise click.ClickException(
+                    f"Service '{name}' declares unknown restart dependent "
+                    f"'{dependent_name}'."
+                )
+            visit(dependent_name)
+        visiting.remove(name)
+        visited.add(name)
+
+    for target in requested_targets:
+        visit(target)
+
+    return services

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -98,6 +98,34 @@ def test_restart_single_service_schedules_only_that_service(monkeypatch):
     assert warnings == []
 
 
+def test_restart_livekit_server_includes_agent_dependent(monkeypatch):
+    popen_calls = []
+    warnings = []
+
+    class FakePopen:
+        def __init__(self, *args, **kwargs):
+            popen_calls.append((args, kwargs))
+
+    monkeypatch.setattr(InstallationConfig, "exists", classmethod(lambda cls: True))
+    monkeypatch.setattr(restart_module.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(
+        restart_module,
+        "warn_before_voice_interruption",
+        lambda **kwargs: warnings.append(kwargs),
+    )
+
+    result = CliRunner().invoke(
+        restart, ["--service", "livekit-server", "--delay", "0"]
+    )
+
+    assert result.exit_code == 0
+    assert "Scheduled restart for livekit-server, livekit-agent" in result.output
+    command = popen_calls[0][0][0][2]
+    assert "livekit-server" in command
+    assert "livekit-agent" in command
+    assert warnings == [{"reason": "restart", "emit_cli_warning": True}]
+
+
 def test_restart_optional_device_sync_can_be_targeted_explicitly(monkeypatch):
     popen_calls = []
 
@@ -121,6 +149,12 @@ def test_restart_codex_app_server_only_targets_codex_service():
     plan = build_restart_plan(RestartRequest(services=("codex-app-server",)))
 
     assert plan.services == ("codex-app-server",)
+
+
+def test_restart_plan_expands_livekit_server_dependent():
+    plan = build_restart_plan(RestartRequest(services=("livekit-server",)))
+
+    assert plan.services == ("livekit-server", "livekit-agent")
 
 
 def test_restart_super_agents_mcp_is_not_a_valid_target():
@@ -161,9 +195,13 @@ def test_execute_recreate_dispatcher_warms_thread_after_services_start(monkeypat
     monkeypatch.setattr(
         restart_module,
         "require_installation",
-        lambda: InstallationConfig(workspace_path="/tmp/workspace", env_file="/tmp/.env"),
+        lambda: InstallationConfig(
+            workspace_path="/tmp/workspace", env_file="/tmp/.env"
+        ),
     )
-    monkeypatch.setattr(restart_module, "launchctl_status", lambda _svc: {"installed": True})
+    monkeypatch.setattr(
+        restart_module, "launchctl_status", lambda _svc: {"installed": True}
+    )
     monkeypatch.setattr(
         restart_module,
         "launchctl_bootout",
@@ -199,3 +237,45 @@ def test_execute_recreate_dispatcher_warms_thread_after_services_start(monkeypat
     )
 
     assert calls == ["prepare", "stop:livekit-agent", "start:livekit-agent", "warm"]
+
+
+def test_execute_restart_plan_stops_dependents_first(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        restart_module,
+        "require_installation",
+        lambda: InstallationConfig(
+            workspace_path="/tmp/workspace", env_file="/tmp/.env"
+        ),
+    )
+    monkeypatch.setattr(
+        restart_module, "launchctl_status", lambda _svc: {"installed": True}
+    )
+    monkeypatch.setattr(
+        restart_module,
+        "launchctl_bootout",
+        lambda svc: calls.append(f"stop:{svc.name}"),
+    )
+    monkeypatch.setattr(
+        restart_module,
+        "install_service",
+        lambda _config, svc: calls.append(f"start:{svc.name}"),
+    )
+    monkeypatch.setattr(restart_module.time, "sleep", lambda _seconds: None)
+
+    execute_restart_plan(
+        RestartPlan(
+            services=("livekit-server", "livekit-agent"),
+            recreate_dispatcher=False,
+            interrupts_voice=False,
+            delay_seconds=0,
+        )
+    )
+
+    assert calls == [
+        "stop:livekit-agent",
+        "stop:livekit-server",
+        "start:livekit-server",
+        "start:livekit-agent",
+    ]


### PR DESCRIPTION
## Summary
- add explicit restart dependent metadata to service definitions
- restart expanded dependents with dependencies started first and dependents stopped first
- make restarting livekit-server include livekit-agent so the worker re-registers
- show expanded service list in restart CLI output

## Tests
- uv run --extra dev pytest tests/test_restart.py
- uv run --extra dev ruff check openbase_coder_cli/cli/restart.py openbase_coder_cli/services/definitions.py openbase_coder_cli/services/restart.py tests/test_restart.py