### PR TITLE
Skip backend-scoped services in doctor and health warnings

### DIFF
--- a/openbase_coder_cli/cli/doctor.py
+++ b/openbase_coder_cli/cli/doctor.py
@@ -38,6 +38,7 @@ from openbase_coder_cli.runtime import stable_runtime_package
 from openbase_coder_cli.services.definitions import SERVICES
 from openbase_coder_cli.services.installation import InstallationConfig
 from openbase_coder_cli.services.launchd import launchctl_status
+from openbase_coder_cli.services.selection import configured_coding_backend
 from openbase_coder_cli.services.tailscale_serve import tailscale_serve_health
 from openbase_coder_cli.stt_providers import (
     LOCAL_MLX_WHISPER_STT_PROVIDER_ID,
@@ -628,7 +629,11 @@ def doctor() -> None:
     # --- Service health ---
     click.echo()
     click.echo(click.style("Service Health", bold=True))
+    coding_backend = configured_coding_backend()
     for svc in SERVICES:
+        if not svc.supports_backend(coding_backend):
+            ok(f"{svc.name}: not used ({coding_backend} backend)")
+            continue
         info = launchctl_status(svc)
         required = getattr(svc, "install_by_default", True)
         if not info["installed"]:

--- a/openbase_coder_cli/openbase_coder_cli_app/health_warnings.py
+++ b/openbase_coder_cli/openbase_coder_cli_app/health_warnings.py
@@ -55,9 +55,15 @@ def _warning(
 def _service_warnings() -> list[dict[str, str]]:
     from openbase_coder_cli.services.definitions import SERVICES
     from openbase_coder_cli.services.launchd import launchctl_status
+    from openbase_coder_cli.services.selection import configured_coding_backend
 
     warnings: list[dict[str, str]] = []
+    coding_backend = configured_coding_backend()
     for service in SERVICES:
+        if not service.supports_backend(coding_backend):
+            # Backend-scoped services (e.g. the Codex App Server on the
+            # claude_code backend) are intentionally not installed.
+            continue
         conditional = _CONDITIONAL_SERVICES.get(service.name)
         expected = conditional() if conditional else service.install_by_default
         try:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -154,10 +154,17 @@ def test_doctor_allows_optional_stopped_services(monkeypatch, tmp_path):
             workspace_path=str(tmp_path),
         ),
     )
+    monkeypatch.setattr(doctor_cli, "configured_coding_backend", lambda: "codex")
     monkeypatch.setattr(
         doctor_cli,
         "SERVICES",
-        [SimpleNamespace(name="codex-thread-device-sync", install_by_default=False)],
+        [
+            SimpleNamespace(
+                name="codex-thread-device-sync",
+                install_by_default=False,
+                supports_backend=lambda _backend: True,
+            )
+        ],
     )
     monkeypatch.setattr(
         doctor_cli,
@@ -221,6 +228,96 @@ def test_doctor_allows_optional_stopped_services(monkeypatch, tmp_path):
     assert "codex-thread-device-sync: optional (not running" in result.output
 
 
+def test_doctor_skips_backend_scoped_services_on_other_backends(
+    monkeypatch, tmp_path
+):
+    env_file = tmp_path / ".env"
+    env_file.write_text("OPENBASE_CODER_CLI_SECRET_KEY=x\n", encoding="utf-8")
+    monkeypatch.setattr(doctor_cli.InstallationConfig, "exists", lambda: True)
+    monkeypatch.setattr(
+        doctor_cli.InstallationConfig,
+        "load",
+        lambda: SimpleNamespace(
+            standalone=False,
+            workspace_path=str(tmp_path),
+            package_path="",
+            python_path="",
+            livekit_server_path="",
+            console_build_dir="",
+        ),
+    )
+    monkeypatch.setattr(
+        doctor_cli, "configured_coding_backend", lambda: "claude_code"
+    )
+    monkeypatch.setattr(
+        doctor_cli,
+        "SERVICES",
+        [
+            SimpleNamespace(
+                name="codex-app-server",
+                install_by_default=True,
+                supports_backend=lambda backend: backend
+                in ("codex", "openbase_cloud"),
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        doctor_cli,
+        "launchctl_status",
+        lambda _svc: {"installed": False, "pid": None, "last_exit_code": None},
+    )
+    monkeypatch.setattr(
+        doctor_cli,
+        "_get_listening_sockets",
+        lambda: [("127.0.0.1", 7999), ("127.0.0.1", 7880)],
+    )
+    monkeypatch.setattr(doctor_cli, "DEFAULT_ENV_FILE_PATH", env_file)
+    monkeypatch.setattr(
+        doctor_cli,
+        "_parse_env_file",
+        lambda: {
+            "OPENBASE_CODER_CLI_SECRET_KEY": "secret",
+            "LIVEKIT_API_KEY": "server-key",
+            "LIVEKIT_API_SECRET": "server-secret",
+            "LIVEKIT_CLIENT_API_KEY": "client-key",
+            "LIVEKIT_CLIENT_API_SECRET": "client-secret",
+            "OPENBASE_CODING_BACKEND": "claude_code",
+        },
+    )
+    monkeypatch.setattr(
+        doctor_cli,
+        "tailscale_serve_health",
+        lambda: SimpleNamespace(
+            tailscale_available=True,
+            tailscale_running=True,
+            host="mac.tailnet.ts.net",
+            openbase_url="http://mac.tailnet.ts.net:18080",
+            openbase_configured=True,
+            livekit_configured=True,
+            openbase_reachable=True,
+            error=None,
+        ),
+    )
+    monkeypatch.setattr(doctor_cli, "selected_tts_provider_id", lambda: "cartesia")
+    monkeypatch.setattr(doctor_cli, "selected_stt_provider_id", lambda: "assemblyai")
+    monkeypatch.setattr(
+        doctor_cli,
+        "claude_auth_status",
+        lambda: SimpleNamespace(logged_in=True, raw_output="", returncode=0),
+    )
+    monkeypatch.setattr(
+        doctor_cli.Path,
+        "home",
+        classmethod(lambda cls: tmp_path),
+    )
+
+    result = CliRunner().invoke(doctor_cli.doctor)
+
+    assert result.exit_code == 0, result.output
+    assert "codex-app-server: not used (claude_code backend)" in result.output
+    assert "codex-app-server: not installed" not in result.output
+
+
 def test_doctor_reports_missing_tailscale_as_setup_action(monkeypatch, tmp_path):
     env_file = tmp_path / ".env"
     env_file.write_text("OPENBASE_CODER_CLI_SECRET_KEY=x\n", encoding="utf-8")
@@ -233,6 +330,7 @@ def test_doctor_reports_missing_tailscale_as_setup_action(monkeypatch, tmp_path)
             workspace_path=str(tmp_path),
         ),
     )
+    monkeypatch.setattr(doctor_cli, "configured_coding_backend", lambda: "codex")
     monkeypatch.setattr(doctor_cli, "SERVICES", [])
     monkeypatch.setattr(doctor_cli, "_get_listening_sockets", lambda: [])
     monkeypatch.setattr(doctor_cli, "DEFAULT_ENV_FILE_PATH", env_file)

--- a/tests/test_health_warnings.py
+++ b/tests/test_health_warnings.py
@@ -19,6 +19,10 @@ from openbase_coder_cli.openbase_coder_cli_app import health_warnings as hw
 class FakeService:
     name: str
     install_by_default: bool = True
+    backends: tuple[str, ...] | None = None
+
+    def supports_backend(self, coding_backend: str) -> bool:
+        return self.backends is None or coding_backend in self.backends
 
 
 def test_expected_service_not_running_warns(monkeypatch) -> None:
@@ -65,6 +69,32 @@ def test_conditional_service_expected_only_when_enabled(monkeypatch) -> None:
         assert hw._service_warnings() == []
     finally:
         hw._CONDITIONAL_SERVICES["code-sync"] = hw._code_sync_expected
+
+
+def test_backend_scoped_service_not_expected_on_other_backend(monkeypatch) -> None:
+    services = [
+        FakeService("django-cli"),
+        FakeService("codex-app-server", backends=("codex", "openbase_cloud")),
+    ]
+    monkeypatch.setattr("openbase_coder_cli.services.definitions.SERVICES", services)
+    monkeypatch.setattr(
+        "openbase_coder_cli.services.launchd.launchctl_status",
+        lambda svc: {"installed": svc.name == "django-cli", "pid": 123},
+    )
+    monkeypatch.setattr(
+        "openbase_coder_cli.services.selection.configured_coding_backend",
+        lambda: "claude_code",
+    )
+
+    assert hw._service_warnings() == []
+
+    monkeypatch.setattr(
+        "openbase_coder_cli.services.selection.configured_coding_backend",
+        lambda: "codex",
+    )
+    assert [w["id"] for w in hw._service_warnings()] == [
+        "service-missing:codex-app-server"
+    ]
 
 
 def test_collect_skips_sync_checks_when_disabled(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Doctor and the health-warnings API expected every `install_by_default` service on all backends, so `claude_code` installs reported a false critical warning: *Expected service 'codex-app-server' is not installed.* Both surfaces now filter by the configured coding backend, completing the fix 82bbb00 applied to the /api/status/ view.

## Testing
- `uv run pytest tests/test_doctor.py tests/test_health_warnings.py` — 21 passed, including new regression tests for backend-scoped skips on both surfaces.

## Note
- The launchd bootstrap-kickstart change that briefly rode along on this branch has been split out for independent review (evidence and open questions documented there).