### PR TITLE
Kickstart re-bootstrapped launchd jobs

### DIFF
--- a/openbase_coder_cli/services/launchd.py
+++ b/openbase_coder_cli/services/launchd.py
@@ -437,6 +437,10 @@ def launchctl_bootstrap(svc: ServiceDefinition) -> None:
         time.sleep(0.5 * (attempt + 1))
         result = _launchctl("bootstrap", domain, str(plist), check=False)
         if result.returncode == 0:
+            # RunAtLoad is not honored when re-bootstrapping a label that was
+            # just booted out, leaving the job loaded but never spawned.
+            # Kickstart (without -k) to guarantee a start either way.
+            _launchctl("kickstart", f"{domain}/{label}", check=False)
             return
     raise click.ClickException(f"Failed to bootstrap {label}: {result.stderr.strip()}")
 

--- a/openbase_coder_cli/services/launchd.py
+++ b/openbase_coder_cli/services/launchd.py
@@ -437,9 +437,11 @@ def launchctl_bootstrap(svc: ServiceDefinition) -> None:
         time.sleep(0.5 * (attempt + 1))
         result = _launchctl("bootstrap", domain, str(plist), check=False)
         if result.returncode == 0:
-            # RunAtLoad is not honored when re-bootstrapping a label that was
-            # just booted out, leaving the job loaded but never spawned.
-            # Kickstart (without -k) to guarantee a start either way.
+            # An intermittent macOS state has been observed where bootstrap
+            # succeeds but the job stays loaded without a PID, despite
+            # RunAtLoad and KeepAlive (mechanism unconfirmed). Kickstart
+            # without -k is a no-op for a running job and safely ensures the
+            # newly registered job is asked to run.
             _launchctl("kickstart", f"{domain}/{label}", check=False)
             return
     raise click.ClickException(f"Failed to bootstrap {label}: {result.stderr.strip()}")

--- a/tests/test_launchd_wrapper.py
+++ b/tests/test_launchd_wrapper.py
@@ -88,3 +88,42 @@ def test_launchctl_bootstrap_reenables_disabled_label(tmp_path, monkeypatch):
     assert calls.index(("enable", "gui/501/com.openbase.coder.sample")) < calls.index(
         ("bootstrap", "gui/501", str(plist))
     )
+
+
+def test_launchctl_bootstrap_kickstarts_once_after_successful_bootstrap(
+    tmp_path, monkeypatch
+):
+    service = ServiceDefinition(
+        name="sample",
+        description="Sample",
+        command_template="exec true",
+        workdir_template="{workspace}",
+    )
+    plist = tmp_path / "sample.plist"
+    calls = []
+    bootstrap_returncodes = iter([5, 5, 0])
+
+    def fake_launchctl(*args, check=True):
+        calls.append(args)
+        code = next(bootstrap_returncodes) if args[0] == "bootstrap" else 0
+        return subprocess.CompletedProcess(["launchctl", *args], code, "", "")
+
+    monkeypatch.setattr(launchd, "_is_macos", lambda: True)
+    monkeypatch.setattr(launchd, "_uid", lambda: 501)
+    monkeypatch.setattr(launchd, "_plist_path", lambda _svc: plist)
+    monkeypatch.setattr(launchd, "_prepare_service_start", lambda _svc: None)
+    monkeypatch.setattr(launchd.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(launchd, "_launchctl", fake_launchctl)
+
+    launchd.launchctl_bootstrap(service)
+
+    target = "gui/501/com.openbase.coder.sample"
+    bootstrap_indexes = [i for i, c in enumerate(calls) if c[0] == "bootstrap"]
+    kickstart_calls = [c for c in calls if c[0] == "kickstart"]
+
+    # Exactly one kickstart, for the same service target, without -k.
+    assert kickstart_calls == [("kickstart", target)]
+    # It immediately follows the successful (final) bootstrap, so the two
+    # failed attempts before it ran without a kickstart.
+    assert len(bootstrap_indexes) == 3
+    assert calls.index(("kickstart", target)) == bootstrap_indexes[-1] + 1


### PR DESCRIPTION
## Summary
Kickstart a launchd job right after a successful bootstrap so service start no longer depends on `RunAtLoad`/`KeepAlive` firing.

**Draft status:** split out of #14 for independent review. The field failure below is documented, but the mechanism stated in the code comment is unproven, a minimal reproduction is still missing, and there is no focused regression test yet. Review skepticism welcome.

## Field evidence (macOS 26.5.1 / 25F80, 2026-07-14)
During an install test (full uninstall, then first install of the released 0.1.10 DMG with CLI 0.15.0):

- Twice in a row, after the app's setup step completed, all six `com.openbase.coder.*` jobs were registered but had no process: `launchctl list` showed `-` for PID; `launchctl print gui/501/com.openbase.coder.django-cli` showed `state = not running` and `last exit code = (never exited)`; nothing listened on 7999, so the Tailscale Serve health check reported HTTP 502 and onboarding surfaced an error.
- The state was stable for minutes despite `KeepAlive=true` in the generated plists — recovery only happened when `launchctl kickstart` was run manually on each label, after which every job spawned immediately and health went 200.
- A third setup pass ~15 minutes later spawned all six jobs normally with no intervention, so the failure is intermittent and likely a race around rapid bootout→bootstrap churn (setup reinstalls all six labels in quick succession).
- A single-label disposable repro (bootstrap → bootout → recreate → bootstrap) on the same macOS build did **not** reproduce, which fits the race interpretation.

## Open questions before merge
- Actual mechanism: the code comment blames `RunAtLoad`, but `KeepAlive=true` should keep the job running regardless, so the true failure mode in launchd is not understood.
- A reproduction that captures `launchctl print` immediately after the failing bootstrap (not minutes later) is still needed, ideally with the six-label churn setup performs.
- No regression test covers this path; one should exist before merge (or this ships explicitly as a defensive mitigation with the comment reworded to say the mechanism is unconfirmed).

## Testing
- Not yet covered by automated tests (see above). Manual: `launchctl kickstart` on affected labels resolved the dead-service state both times in the field.