### PR TITLE
Handle incompatible Codex thread rollouts

### DIFF
--- a/openbase_coder_cli/openbase_coder_cli_app/consumers.py
+++ b/openbase_coder_cli/openbase_coder_cli_app/consumers.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-import json
 import logging
 
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 
 from openbase_coder_cli.mcp.session_manager import get_session_manager
+from openbase_coder_cli.openbase_coder_cli_app.thread_errors import (
+    thread_error_code,
+    thread_error_message,
+)
 from openbase_coder_cli.openbase_coder_cli_app.thread_metadata import (
     annotate_thread_payload,
 )
@@ -16,19 +19,8 @@ logger = logging.getLogger(__name__)
 
 
 def _friendly_error(exc: Exception) -> str:
-    """Extract a human-readable message from manager errors.
-
-    The session manager bubbles up codex app-server JSON-RPC errors as
-    RuntimeError("{json}"), which is unhelpful when surfaced to the UI.
-    """
-    raw = str(exc)
-    try:
-        payload = json.loads(raw)
-    except (ValueError, TypeError):
-        return raw
-    if isinstance(payload, dict) and isinstance(payload.get("message"), str):
-        return payload["message"]
-    return raw
+    """Extract a safe human-readable message from manager errors."""
+    return thread_error_message(exc)
 
 
 class ThreadConsumer(AsyncJsonWebsocketConsumer):
@@ -57,7 +49,10 @@ class ThreadConsumer(AsyncJsonWebsocketConsumer):
                     "type": "error",
                     "data": {
                         "message": _friendly_error(exc),
-                        "code": "thread_state_unavailable",
+                        "code": thread_error_code(
+                            exc,
+                            fallback="thread_state_unavailable",
+                        ),
                     },
                 }
             )

--- a/openbase_coder_cli/openbase_coder_cli_app/thread_errors.py
+++ b/openbase_coder_cli/openbase_coder_cli_app/thread_errors.py
@@ -1,0 +1,45 @@
+"""Translate thread-store failures into stable user-facing states."""
+
+from __future__ import annotations
+
+import json
+
+THREAD_VERSION_UNAVAILABLE_CODE = "thread_version_unavailable"
+THREAD_VERSION_UNAVAILABLE_MESSAGE = (
+    "This thread was created by a newer Codex version and cannot be opened "
+    "in this version of Openbase yet. You can return to Threads or try again "
+    "after updating Openbase."
+)
+
+
+def is_thread_version_unavailable_error(exc: Exception) -> bool:
+    """Return whether Codex rejected a rollout written by another version."""
+    message = _error_message(exc).casefold()
+    return (
+        "failed to read thread" in message
+        and "does not start with session metadata" in message
+    )
+
+
+def thread_error_message(exc: Exception) -> str:
+    """Return a useful message without exposing local paths or internals."""
+    if is_thread_version_unavailable_error(exc):
+        return THREAD_VERSION_UNAVAILABLE_MESSAGE
+    return _error_message(exc)
+
+
+def thread_error_code(exc: Exception, *, fallback: str) -> str:
+    if is_thread_version_unavailable_error(exc):
+        return THREAD_VERSION_UNAVAILABLE_CODE
+    return fallback
+
+
+def _error_message(exc: Exception) -> str:
+    raw = str(exc)
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        return raw
+    if isinstance(payload, dict) and isinstance(payload.get("message"), str):
+        return payload["message"]
+    return raw

--- a/openbase_coder_cli/openbase_coder_cli_app/threads.py
+++ b/openbase_coder_cli/openbase_coder_cli_app/threads.py
@@ -28,6 +28,11 @@ from openbase_coder_cli.openbase_coder_cli_app.thread_cache import (
     get_cached_thread_state,
     invalidate_thread_list_cache,
 )
+from openbase_coder_cli.openbase_coder_cli_app.thread_errors import (
+    THREAD_VERSION_UNAVAILABLE_CODE,
+    is_thread_version_unavailable_error,
+    thread_error_message,
+)
 from openbase_coder_cli.openbase_coder_cli_app.thread_favorites import (
     favorite_payload,
     is_thread_favorite,
@@ -407,7 +412,22 @@ def thread_detail(request, thread_id):
         invalidate_thread_list_cache()
         return Response({"success": True})
 
-    thread = async_to_sync(manager.get_thread_state)(thread_id)
+    try:
+        thread = async_to_sync(manager.get_thread_state)(thread_id)
+    except RuntimeError as exc:
+        if not is_thread_version_unavailable_error(exc):
+            raise
+        logger.info(
+            "thread_detail version-incompatible rollout thread_id=%s",
+            thread_id,
+        )
+        return Response(
+            {
+                "error": thread_error_message(exc),
+                "code": THREAD_VERSION_UNAVAILABLE_CODE,
+            },
+            status=status.HTTP_409_CONFLICT,
+        )
     if thread is None:
         return Response(
             {"error": f"Thread {thread_id} not found"},

--- a/tests/test_thread_errors.py
+++ b/tests/test_thread_errors.py
@@ -1,0 +1,32 @@
+from openbase_coder_cli.openbase_coder_cli_app.thread_errors import (
+    THREAD_VERSION_UNAVAILABLE_CODE,
+    is_thread_version_unavailable_error,
+    thread_error_code,
+    thread_error_message,
+)
+
+
+def test_version_skew_error_hides_thread_store_internals() -> None:
+    exc = RuntimeError(
+        '{"code": -32603, "message": "failed to read thread: '
+        "thread-store internal error: failed to read /Users/example/rollout.jsonl: "
+        'rollout does not start with session metadata"}'
+    )
+
+    assert is_thread_version_unavailable_error(exc) is True
+    assert thread_error_code(exc, fallback="thread_state_unavailable") == (
+        THREAD_VERSION_UNAVAILABLE_CODE
+    )
+    message = thread_error_message(exc)
+    assert "newer Codex version" in message
+    assert "/Users/example" not in message
+
+
+def test_other_thread_errors_keep_their_message_and_fallback_code() -> None:
+    exc = RuntimeError('{"code": -32000, "message": "Thread not found"}')
+
+    assert is_thread_version_unavailable_error(exc) is False
+    assert thread_error_message(exc) == "Thread not found"
+    assert thread_error_code(exc, fallback="thread_state_unavailable") == (
+        "thread_state_unavailable"
+    )

--- a/tests/test_threads_api.py
+++ b/tests/test_threads_api.py
@@ -51,6 +51,14 @@ class FakeThreadManager:
         )
 
 
+class IncompatibleThreadManager(FakeThreadManager):
+    async def get_thread_state(self, thread_id: str) -> ThreadInfo | None:
+        raise RuntimeError(
+            '{"code": -32603, "message": "failed to read thread: '
+            'thread-store internal error: rollout does not start with session metadata"}'
+        )
+
+
 def _thread(index: int) -> ThreadInfo:
     now = datetime(2026, 5, 28, 12, tzinfo=timezone.utc)
     updated_at = now - timedelta(minutes=index)
@@ -267,6 +275,21 @@ def test_thread_active_voice_returns_404_without_active_thread(monkeypatch) -> N
     assert response.status_code == 404
     assert manager.page_calls == []
     assert manager.thread_state_calls == []
+
+
+def test_thread_detail_returns_clean_conflict_for_version_skew(monkeypatch) -> None:
+    manager = IncompatibleThreadManager([])
+    monkeypatch.setattr(thread_views, "get_session_manager", lambda: manager)
+    factory = APIRequestFactory()
+    request = factory.get("/api/threads/thread-newer/")
+    force_authenticate(request, user=SimpleNamespace(is_authenticated=True))
+
+    response = thread_views.thread_detail(request, "thread-newer")
+
+    assert response.status_code == 409
+    assert response.data["code"] == "thread_version_unavailable"
+    assert "newer Codex version" in response.data["error"]
+    assert "thread-store" not in response.data["error"]
 
 
 def test_thread_list_filters_favorites_without_changing_default_order(


### PR DESCRIPTION
## What changed

- Detects the Codex thread-store incompatibility that currently surfaces as HTTP 500.
- Returns a stable `409 thread_version_unavailable` response for the REST path.
- Maps the same condition over WebSocket and removes local rollout paths and internal parser details from user-facing errors.
- Adds focused regression coverage.

## Root cause

The affected rollout was written by Codex Desktop 0.145 while the installed Openbase runtime was using Codex CLI 0.139. The older app-server rejects the newer rollout schema with a misleading “does not start with session metadata” error even though the metadata exists.

## Validation

- Targeted regression tests: 20 passed.
- Ruff checks passed.
- A wider workspace run previously reached 818 passing tests with four unrelated existing failures in model/default-route assertions.

## Release order

Merge after the shared UI PR. Because CLI `main` publishes the stable runtime, review this before the desktop PR so the desktop package can seed the compatible release. No automatic merge is enabled.