### PR TITLE
Make fresh dev local-audio setup reliable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,32 +80,53 @@ Most users should install the Mac app first:
 Openbase Coder is developed as a multi-repo workspace. Clone the workspace repo
 for source development, even if you are mainly changing the CLI:
 
+Prerequisites are Git, `uv`, Node + pnpm, and Tailscale signed in and connected
+on the Mac. Sign in to the coding backend you plan to use (`codex login` or the
+normal Claude Code login) before setup.
+
 ```bash
 uv tool install multi-workspace
 git clone https://github.com/openbase-community/openbase-coder-workspace
 cd openbase-coder-workspace
-./scripts/setup
+./scripts/setup --backend codex
 ```
 
 The workspace setup syncs the public development repos with `multi`, builds the
-console from source, and runs `openbase-coder setup --workspace-dir` against the
-checkout. The CLI source for this repository lives at `cli/` inside the
-workspace.
+console from source, and runs `openbase-coder setup --workspace-dir` against
+the checkout. Development setup defaults to free local audio, installs the
+Kokoro and MLX Whisper dependencies into the same environment used by the
+services, downloads their models, and refuses to report success until that
+voice pipeline is ready. The first download can take several minutes.
+
+To choose another audio path explicitly, pass `--audio-provider
+openbase-cloud` (requires an active audio subscription) or `--audio-provider
+cartesia` (requires Cartesia and AssemblyAI keys).
+
+Finish and verify the install:
+
+```bash
+openbase-coder login
+openbase-coder doctor
+openbase-coder services status
+```
+
+`doctor` must show Tailscale Serve and the required services running before a
+physical phone can start a call. The CLI source for this repository lives at
+`cli/` inside the workspace.
 
 For CLI-only development after workspace setup:
 
 ```bash
 cd cli
-uv sync --extra dev
+uv sync --extra dev --extra local-audio
 uv run openbase-coder --version
 uv run pytest
 ```
 
-If you want a persistent `openbase-coder` command backed by your checkout:
-
-```bash
-uv tool install -e ./cli
-```
+Keep `--extra local-audio` on later `uv sync` commands; omitting it intentionally
+removes the optional local voice packages. The workspace setup installs the
+persistent `openbase-coder` shim for you, backed by the same workspace venv the
+services use. Do not install a second CLI with `uv tool install`.
 
 ### 📘 Documentation
 

--- a/docs/commands/setup.md
+++ b/docs/commands/setup.md
@@ -41,7 +41,7 @@ you. To run setup yourself from a terminal instead, follow
 
 For development, run the workspace script from your checkout root; it runs
 `multi sync --install-set default` and then
-`openbase-coder setup --workspace-dir <workspace-root>`:
+`openbase-coder setup --workspace-dir <workspace-root> --audio-provider local`:
 
 ```bash
 ./scripts/setup
@@ -50,6 +50,8 @@ For development, run the workspace script from your checkout root; it runs
 The workspace script is for a clean source-workspace install. If it finds an
 existing standalone install or a different development workspace install, it
 stops and directs you to [Uninstall](../uninstall.md) before making changes.
+The development wrapper defaults to free local audio; pass an explicit
+`--audio-provider` to override it.
 
 ## Backend Selection
 
@@ -81,9 +83,10 @@ Anthropic's official native installer. Backend-specific services (such as
 gated-out services.
 
 With `--audio-provider local`, setup installs the optional Kokoro/MLX local
-audio dependencies and downloads the required models. Standalone packages
-should be built with Python 3.12 for this path because Kokoro currently
-declares Python `<3.13`.
+audio dependencies and downloads the required models. In development it keeps
+the `local-audio` uv extra in the workspace environment, installs Kokoro's
+English language model, and verifies the active service runtime plus both
+model caches before setup succeeds.
 
 ## Options
 
@@ -117,7 +120,7 @@ declares Python `<3.13`.
 10. Renders shared default instruction files from the bundled package or workspace `instructions/` into `~/.openbase/instructions/`.
 11. Creates missing `~/.openbase/dispatcher-config.json` with default dispatcher reasoning effort `low`, default Super Agents reasoning effort `high`, and backend-specific default model settings.
 12. Symlinks bundled or workspace skills into `~/.openbase/codex_home/skills` and `~/.openbase/claude_config/skills`.
-13. Initializes runtime assets: in development mode runs `uv sync` in `cli`; in **both** modes downloads the LiveKit agent model files (VAD, turn detector) so the first voice session does not stall on downloads.
+13. Initializes runtime assets: in development mode runs `uv sync` in `cli` (including the `local-audio` extra when selected); in **both** modes downloads the LiveKit agent model files (VAD, turn detector) so the first voice session does not stall on downloads. Local audio setup then downloads Kokoro voices, the Kokoro English language model, and MLX Whisper, and fails setup if the active runtime is not ready.
 14. Installs the bundled `inject-session-id.sh` SessionStart hook script into `~/.openbase/hooks/` and registers it in both Openbase agent homes: a `hooks.SessionStart` entry in `~/.openbase/claude_config/settings.json` and a trusted `[[hooks.SessionStart]]` hook (with its `[hooks.state]` trust entry) in `~/.openbase/codex_home/config.toml`. The hook feeds each session's thread/session ID back into the conversation together with the instructions for using it, so agents stamp commits with the `Agent-Thread-Id` trailer without needing any standing `AGENTS.md` rule.
 15. Configures `~/.openbase/codex_home/config.toml` with full Codex local access (`sandbox_mode = "danger-full-access"`), disabled permission prompts, and the Super Agents MCP server. With `--link-codex-config`, this path is first linked to `~/.codex/config.toml`. The MCP command prefers the selected workspace's venv executable and falls back to the resolved local `uv` path.
 16. Configures `~/.openbase/claude_config/.claude.json` with the Super Agents MCP server and writes `CLAUDE_CONFIG_DIR=~/.openbase/claude_config` into the shared `.env`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,8 +20,9 @@ Openbase Coder has exactly two deployment modes:
   console, agent instructions, and skills. It is detected automatically via
   `openbase-coder-package.json`.
 - **Development**: a cloned `openbase-coder-workspace` checkout set up with the
-  workspace's `./scripts/setup` script, with the CLI installed editable
-  (`uv tool install -e ./cli`) or run via `uv run`.
+  workspace's `./scripts/setup` script. The script installs a persistent shim
+  backed by the workspace venv; do not create a second CLI environment with
+  `uv tool install`.
 
 Git, `uv`, and Node/npm are only needed for Openbase Coder development.
 Plugins no longer need Node/npm: plugin console pages ship prebuilt static
@@ -29,7 +30,9 @@ assets rendered in iframes.
 
 Local Kokoro/MLX audio is optional. When setup is run with
 `--audio-provider local`, the CLI installs the local-audio Python packages into
-the bundled runtime and downloads the Kokoro voices and MLX Whisper model.
+the active runtime and downloads the Kokoro voices, English language model,
+and MLX Whisper model. The development workspace wrapper selects this free
+local path by default.
 
 Optional:
 
@@ -67,6 +70,16 @@ cd openbase-coder-workspace
 ./scripts/setup
 ```
 
+The workspace script defaults to local audio and verifies the dependencies and
+models before installing services. Pass `--backend codex` or
+`--backend claude-code` to avoid the interactive backend prompt. After setup,
+keep the voice extra when syncing CLI development dependencies:
+
+```bash
+cd cli
+uv sync --extra dev --extra local-audio
+```
+
 If a standalone desktop/CLI install, or a different development workspace
 install, already exists, the workspace script stops and links to
 [Uninstall](uninstall.md). Uninstall first, then rerun `./scripts/setup`.
@@ -94,7 +107,7 @@ What setup does:
 4. Installs the selected backend's CLI on demand if missing (codex from GitHub release binaries into `~/.openbase/bin`, claude via Anthropic's official installer).
 5. Generates Openbase instruction files from bundled or workspace templates, links Openbase Claude instructions to the generated Openbase AGENTS file, and keeps normal Claude linked to normal Codex AGENTS.
 6. Symlinks bundled or workspace skills into both Openbase Codex and Claude config skill homes.
-7. Downloads LiveKit agent model files (VAD, turn detector) in both modes, and initializes the CLI venv with `uv sync` in development mode.
+7. Downloads LiveKit agent model files (VAD, turn detector) in both modes, initializes the CLI venv with `uv sync` in development mode, and keeps the `local-audio` extra plus its verified model caches when local audio is selected.
 8. Writes Codex app-server defaults such as `CODEX_MODEL=gpt-5.5`, `CODEX_MODEL_REASONING_EFFORT=high`, `CODEX_SERVICE_TIER=standard`, `CODEX_APP_SERVER_URL`, and `LIVEKIT_CODEX_THREAD_CWD`.
 9. Uses the bundled console build, or builds `console` in development mode.
 10. Installs background services — launchd on macOS, systemd user units on Linux (unless `--skip-services`). Backend-specific services such as `codex-app-server` are only installed for the codex/openbase-cloud backends.

--- a/openbase_coder_cli/cli/setup/__init__.py
+++ b/openbase_coder_cli/cli/setup/__init__.py
@@ -76,15 +76,16 @@ from openbase_coder_cli.cli.setup.dispatcher import (
     AUDIO_PROVIDER_OPTIONS,
     CODEX_HOME_DEFAULT_DISPATCHER_CONFIG,  # noqa: F401
     DEFAULT_AUDIO_PROVIDER,  # noqa: F401
-    LOCAL_AUDIO_PYTHON_MAX,  # noqa: F401
     LOCAL_AUDIO_REQUIREMENTS,  # noqa: F401
+    LOCAL_AUDIO_SPACY_MODEL,  # noqa: F401
     _audio_provider_config,  # noqa: F401
     _default_dispatcher_config,  # noqa: F401
     _download_local_audio_models,
     _ensure_codex_home_dispatcher_config,
     _ensure_local_audio_dependencies,
+    _ensure_local_audio_ready,
     _local_audio_dependencies_available,  # noqa: F401
-    _python_version,  # noqa: F401
+    _local_audio_spacy_model_available,  # noqa: F401
     _update_dispatcher_audio_provider,  # noqa: F401
 )
 from openbase_coder_cli.cli.setup.env import (
@@ -525,16 +526,21 @@ def _run_setup_phases(
         f"Voice dispatcher service tier: {'fast' if fast_mode else 'standard'} "
         "(Super Agents: standard; both adjustable in console settings)."
     )
-    if audio_provider == AUDIO_PROVIDER_LOCAL:
-        _ensure_local_audio_dependencies(runtime_package)
-        _download_local_audio_models()
     _symlink_codex_home_skills(workspace_dir if use_dev_workspace else "")
 
     # --- Initialize runtime assets ---
     if use_dev_workspace:
-        _init_cli_workspace(workspace_dir)
+        _init_cli_workspace(
+            workspace_dir,
+            include_local_audio=audio_provider == AUDIO_PROVIDER_LOCAL,
+        )
     else:
         _init_standalone_runtime(runtime_package)
+
+    if audio_provider == AUDIO_PROVIDER_LOCAL:
+        _ensure_local_audio_dependencies(runtime_package)
+        _download_local_audio_models()
+        _ensure_local_audio_ready()
 
     # --- Configure the service CODEX_HOME ---
     _ensure_session_id_hook_script()

--- a/openbase_coder_cli/cli/setup/dispatcher.py
+++ b/openbase_coder_cli/cli/setup/dispatcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -15,6 +16,7 @@ from openbase_coder_cli.dispatcher_config import (
     STT_PROVIDER_KEY,
     TTS_PROVIDER_KEY,
 )
+from openbase_coder_cli.local_audio_readiness import local_audio_readiness
 from openbase_coder_cli.paths import (
     CODEX_DISPATCHER_CONFIG_PATH,
 )
@@ -52,8 +54,11 @@ LOCAL_AUDIO_REQUIREMENTS = (
     "huggingface-hub>=0.36.0",
     "kokoro>=0.9.4",
     "mlx-whisper>=0.4.3",
+    "numba>=0.65.0",
+    "numpy>=2.3.0,<2.5",
 )
-LOCAL_AUDIO_PYTHON_MAX = (3, 13)
+LOCAL_AUDIO_SPACY_MODEL = "en_core_web_sm"
+MODEL_DOWNLOAD_OFFLINE_ENV_KEYS = ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE")
 
 
 def _ensure_codex_home_dispatcher_config(audio_provider: str | None = None) -> None:
@@ -124,6 +129,14 @@ def _audio_provider_config(audio_provider: str) -> dict[str, str]:
 
 
 def _download_local_audio_models() -> None:
+    removed_offline_flags = [
+        key for key in MODEL_DOWNLOAD_OFFLINE_ENV_KEYS if os.environ.pop(key, None)
+    ]
+    if removed_offline_flags:
+        click.echo(
+            "Ignoring obsolete offline model flags during setup: "
+            + ", ".join(removed_offline_flags)
+        )
     click.echo("Downloading local TTS voices...")
     tts_status = get_tts_provider(KOKORO_PROVIDER_ID).download_all_voices()
     if not tts_status.ready:
@@ -139,38 +152,71 @@ def _download_local_audio_models() -> None:
     click.echo("Downloaded local voice audio models.")
 
 
+def _ensure_local_audio_ready() -> None:
+    readiness = local_audio_readiness(
+        tts_provider_id=KOKORO_PROVIDER_ID,
+        stt_provider_id=LOCAL_MLX_WHISPER_STT_PROVIDER_ID,
+    )
+    if not readiness.ready:
+        raise click.ClickException(
+            "Local audio setup did not complete in the active Openbase runtime: "
+            f"{readiness.detail or 'readiness check failed'}. Retry "
+            "`openbase-coder setup --audio-provider local`."
+        )
+    click.echo("Verified local audio runtime and model readiness.")
+
+
 def _ensure_local_audio_dependencies(runtime_package) -> None:
     python_path = (
         runtime_package.python_path if runtime_package else Path(sys.executable)
     )
-    version = _python_version(python_path)
-    if version >= LOCAL_AUDIO_PYTHON_MAX:
-        raise click.ClickException(
-            "Local audio currently requires a Python 3.12 Openbase Coder runtime "
-            "because Kokoro declares Python <3.13. Reinstall Openbase Coder with "
-            "a Python 3.12 standalone package, or use --audio-provider openbase-cloud."
-        )
-    if _local_audio_dependencies_available(python_path):
-        return
+    runtime_bin = str(python_path.parent)
+    existing_path = os.environ.get("PATH", "")
+    pip_env = {
+        **os.environ,
+        "PATH": os.pathsep.join(part for part in (runtime_bin, existing_path) if part),
+        "PIP_BREAK_SYSTEM_PACKAGES": "1",
+    }
+    if not _local_audio_dependencies_available(python_path):
+        click.echo("Installing local audio Python dependencies...")
+        try:
+            subprocess.run(
+                [
+                    str(python_path),
+                    "-m",
+                    "pip",
+                    "install",
+                    "--upgrade",
+                    *LOCAL_AUDIO_REQUIREMENTS,
+                ],
+                check=True,
+                env=pip_env,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise click.ClickException(
+                "Failed to install local audio dependencies. Retry after checking "
+                "network access, or select another audio provider."
+            ) from exc
 
-    click.echo("Installing local audio Python dependencies...")
-    try:
-        subprocess.run(
-            [
-                str(python_path),
-                "-m",
-                "pip",
-                "install",
-                "--upgrade",
-                *LOCAL_AUDIO_REQUIREMENTS,
-            ],
-            check=True,
-        )
-    except subprocess.CalledProcessError as exc:
-        raise click.ClickException(
-            "Failed to install local audio dependencies. "
-            "Use --audio-provider openbase-cloud or retry after checking network access."
-        ) from exc
+    if not _local_audio_spacy_model_available(python_path):
+        click.echo("Installing Kokoro English language model...")
+        try:
+            subprocess.run(
+                [
+                    str(python_path),
+                    "-m",
+                    "spacy",
+                    "download",
+                    LOCAL_AUDIO_SPACY_MODEL,
+                ],
+                check=True,
+                env=pip_env,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise click.ClickException(
+                "Failed to install the Kokoro English language model. Retry after "
+                "checking network access, or select another audio provider."
+            ) from exc
 
 
 def _local_audio_dependencies_available(python_path: Path) -> bool:
@@ -187,20 +233,14 @@ def _local_audio_dependencies_available(python_path: Path) -> bool:
     return result.returncode == 0
 
 
-def _python_version(python_path: Path) -> tuple[int, int]:
+def _local_audio_spacy_model_available(python_path: Path) -> bool:
     result = subprocess.run(
-        [
-            str(python_path),
-            "-c",
-            "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')",
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
+        [str(python_path), "-c", f"import {LOCAL_AUDIO_SPACY_MODEL}"],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
-    major, minor = result.stdout.strip().split(".", 1)
-    return int(major), int(minor)
-
+    return result.returncode == 0
 
 
 

--- a/openbase_coder_cli/cli/setup/env.py
+++ b/openbase_coder_cli/cli/setup/env.py
@@ -26,6 +26,7 @@ from openbase_coder_cli.env_file import (
     env_file_values as _env_file_values,
 )
 from openbase_coder_cli.env_file import (
+    remove_env_file_keys,
     selected_backend_from_env_file,
 )
 from openbase_coder_cli.env_file import (
@@ -35,6 +36,8 @@ from openbase_coder_cli.paths import (
     CODEX_DISPATCHER_CONFIG_PATH,
     OPENBASE_CLAUDE_CONFIG_DIR,
 )
+
+MODEL_DOWNLOAD_OFFLINE_ENV_KEYS = {"HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE"}
 
 
 def _ensure_env_file(
@@ -48,6 +51,9 @@ def _ensure_env_file(
     if coding_backend:
         coding_backend = normalize_backend(coding_backend)
     if path.is_file():
+        removed_offline_flags = remove_env_file_keys(
+            path, MODEL_DOWNLOAD_OFFLINE_ENV_KEYS
+        )
         updates = _missing_livekit_client_credential_values(path)
         if coding_backend:
             updates[CODING_BACKEND_ENV_KEY] = coding_backend
@@ -59,6 +65,11 @@ def _ensure_env_file(
                 click.echo(
                     f"Updated client-facing LiveKit token credentials in {path}."
                 )
+            if removed_offline_flags:
+                click.echo(f"Removed obsolete offline model flags from {path}.")
+            return
+        if removed_offline_flags:
+            click.echo(f"Removed obsolete offline model flags from {path}.")
             return
         click.echo(f".env already exists at {path}, leaving unchanged.")
         return

--- a/openbase_coder_cli/cli/setup/workspace.py
+++ b/openbase_coder_cli/cli/setup/workspace.py
@@ -215,7 +215,11 @@ def _syncthing_global_ignore_path() -> Path:
     return Path.home() / ".config" / "syncthing" / "global.stignore"
 
 
-def _init_cli_workspace(workspace_dir: str) -> None:
+def _init_cli_workspace(
+    workspace_dir: str,
+    *,
+    include_local_audio: bool = False,
+) -> None:
     """Initialize the CLI checkout that now hosts the LiveKit worker."""
     cli_dir = Path(workspace_dir) / "cli"
     if not cli_dir.is_dir():
@@ -231,7 +235,10 @@ def _init_cli_workspace(workspace_dir: str) -> None:
 
     # Create venv and install dependencies
     click.echo("  Running uv sync...")
-    subprocess.run([uv_bin, "sync"], cwd=str(cli_dir), check=True)
+    sync_command = [uv_bin, "sync"]
+    if include_local_audio:
+        sync_command.extend(["--extra", "local-audio"])
+    subprocess.run(sync_command, cwd=str(cli_dir), check=True)
 
     _download_livekit_model_files(
         [uv_bin, "run", "python"],

--- a/openbase_coder_cli/env_file.py
+++ b/openbase_coder_cli/env_file.py
@@ -42,6 +42,18 @@ def upsert_env_file_values(path: Path, values: dict[str, str]) -> None:
     path.write_text("\n".join(updated).rstrip() + "\n", encoding="utf-8")
 
 
+def remove_env_file_keys(path: Path, keys: set[str]) -> bool:
+    """Remove active assignments for ``keys`` while preserving the rest."""
+    if not path.is_file():
+        return False
+    lines = path.read_text(encoding="utf-8").splitlines()
+    filtered = [line for line in lines if active_env_key(line) not in keys]
+    if filtered == lines:
+        return False
+    path.write_text("\n".join(filtered).rstrip() + "\n", encoding="utf-8")
+    return True
+
+
 def selected_backend_from_env_file(path: Path) -> str:
     """The coding backend selected by an env file."""
     values = env_file_values(path)

--- a/openbase_coder_cli/local_audio_readiness.py
+++ b/openbase_coder_cli/local_audio_readiness.py
@@ -1,0 +1,70 @@
+"""One readiness gate for the optional local voice pipeline."""
+
+from __future__ import annotations
+
+import importlib.util
+from dataclasses import dataclass
+
+from openbase_coder_cli.stt_providers import (
+    LOCAL_MLX_WHISPER_STT_PROVIDER_ID,
+    local_mlx_whisper_readiness,
+)
+from openbase_coder_cli.tts_providers import KOKORO_PROVIDER_ID, get_tts_provider
+
+LOCAL_AUDIO_RUNTIME_MODULES = (
+    "huggingface_hub",
+    "kokoro",
+    "mlx_whisper",
+    "en_core_web_sm",
+)
+
+
+@dataclass(frozen=True)
+class LocalAudioReadiness:
+    ready: bool
+    detail: str | None = None
+
+
+def local_audio_readiness(
+    *, tts_provider_id: str, stt_provider_id: str
+) -> LocalAudioReadiness:
+    """Check dependencies and cached models used by the selected providers."""
+    uses_local_audio = (
+        tts_provider_id == KOKORO_PROVIDER_ID
+        or stt_provider_id == LOCAL_MLX_WHISPER_STT_PROVIDER_ID
+    )
+    if not uses_local_audio:
+        return LocalAudioReadiness(ready=True)
+
+    missing_modules = [
+        module
+        for module in LOCAL_AUDIO_RUNTIME_MODULES
+        if importlib.util.find_spec(module) is None
+    ]
+    if missing_modules:
+        return LocalAudioReadiness(
+            ready=False,
+            detail="Missing local audio Python packages: " + ", ".join(missing_modules),
+        )
+
+    if tts_provider_id == KOKORO_PROVIDER_ID:
+        tts_status = get_tts_provider(KOKORO_PROVIDER_ID).readiness()
+        if not tts_status.ready:
+            detail = tts_status.detail or "Kokoro model or voice files are missing."
+            return LocalAudioReadiness(
+                ready=False,
+                detail=(
+                    f"{detail.rstrip('.')} "
+                    f"({tts_status.cached_files}/{tts_status.required_files} cached)."
+                ),
+            )
+
+    if stt_provider_id == LOCAL_MLX_WHISPER_STT_PROVIDER_ID:
+        stt_status = local_mlx_whisper_readiness()
+        if not stt_status.ready:
+            return LocalAudioReadiness(
+                ready=False,
+                detail=stt_status.detail or "Local MLX Whisper model is missing.",
+            )
+
+    return LocalAudioReadiness(ready=True)

--- a/openbase_coder_cli/openbase_coder_cli_app/livekit.py
+++ b/openbase_coder_cli/openbase_coder_cli_app/livekit.py
@@ -63,6 +63,7 @@ from openbase_coder_cli.livekit_voice_route import (
     publish_transfer_to_thread,
     super_agent_voice_for_context,
 )
+from openbase_coder_cli.local_audio_readiness import local_audio_readiness
 from openbase_coder_cli.mcp.session_manager import get_session_manager
 from openbase_coder_cli.openbase_coder_cli_app.common import _request_identity
 from openbase_coder_cli.services.cloud_workspace import cloud_workspace_id
@@ -749,10 +750,29 @@ def livekit_room_token(request):
             }
         )
 
+    tts_provider_id = selected_tts_provider_id()
+    stt_provider_id = selected_stt_provider_id()
+    readiness = local_audio_readiness(
+        tts_provider_id=tts_provider_id,
+        stt_provider_id=stt_provider_id,
+    )
+    if not readiness.ready:
+        return Response(
+            {
+                "detail": (
+                    "Local voice audio is not ready: "
+                    f"{readiness.detail or 'readiness check failed'}. Run "
+                    "`openbase-coder setup --audio-provider local` and try again."
+                ),
+                "code": "local_audio_not_ready",
+            },
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
     try:
         ensure_openbase_cloud_audio_subscription(
-            tts_provider_id=selected_tts_provider_id(),
-            stt_provider_id=selected_stt_provider_id(),
+            tts_provider_id=tts_provider_id,
+            stt_provider_id=stt_provider_id,
             web_backend_url=(
                 getattr(settings, "WEB_BACKEND_URL", "") or DEFAULT_WEB_BACKEND_URL
             ).rstrip("/"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ local-audio = [
     "huggingface-hub>=0.36.0",
     "kokoro>=0.9.4",
     "mlx-whisper>=0.4.3",
+    "numba>=0.65.0",
+    "numpy>=2.3.0,<2.5",
 ]
 
 [build-system]

--- a/tests/test_cartesia_voice_settings.py
+++ b/tests/test_cartesia_voice_settings.py
@@ -419,6 +419,44 @@ def test_livekit_room_token_blocks_openbase_cloud_audio_without_subscription(
     assert response.data["code"] == "subscription_required"
 
 
+def test_livekit_room_token_blocks_incomplete_local_audio(monkeypatch) -> None:
+    monkeypatch.setattr(
+        views._livekit,
+        "_livekit_client_token_credentials",
+        lambda: ("livekit-client-key", "livekit-client-secret"),
+    )
+    monkeypatch.setattr(
+        views._livekit,
+        "selected_tts_provider_id",
+        lambda: "kokoro",
+    )
+    monkeypatch.setattr(
+        views._livekit,
+        "selected_stt_provider_id",
+        lambda: "local_mlx_whisper",
+    )
+    monkeypatch.setattr(
+        views._livekit,
+        "local_audio_readiness",
+        lambda **_kwargs: SimpleNamespace(
+            ready=False,
+            detail="Missing local audio Python packages: kokoro",
+        ),
+    )
+
+    response = views.livekit_room_token(
+        _jwt_authenticated_request(
+            "POST",
+            "/api/livekit-room-token/",
+            {"livekit_dispatch_agent_name": "livekit-agent"},
+        )
+    )
+
+    assert response.status_code == 503
+    assert response.data["code"] == "local_audio_not_ready"
+    assert "setup --audio-provider local" in response.data["detail"]
+
+
 def test_livekit_room_token_includes_proven_cloud_workspace_identity(
     monkeypatch,
 ) -> None:
@@ -431,6 +469,11 @@ def test_livekit_room_token_includes_proven_cloud_workspace_identity(
         views._livekit,
         "ensure_openbase_cloud_audio_subscription",
         lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        views._livekit,
+        "local_audio_readiness",
+        lambda **_kwargs: SimpleNamespace(ready=True, detail=None),
     )
     monkeypatch.setattr(
         views._livekit,

--- a/tests/test_local_audio_readiness.py
+++ b/tests/test_local_audio_readiness.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from openbase_coder_cli import local_audio_readiness as readiness_module
+
+
+def test_local_audio_readiness_reports_missing_runtime_package(monkeypatch) -> None:
+    monkeypatch.setattr(
+        readiness_module.importlib.util,
+        "find_spec",
+        lambda module: None if module == "kokoro" else SimpleNamespace(),
+    )
+
+    readiness = readiness_module.local_audio_readiness(
+        tts_provider_id="kokoro",
+        stt_provider_id="local_mlx_whisper",
+    )
+
+    assert readiness.ready is False
+    assert "kokoro" in readiness.detail
+
+
+def test_local_audio_readiness_checks_both_model_caches(monkeypatch) -> None:
+    monkeypatch.setattr(
+        readiness_module.importlib.util,
+        "find_spec",
+        lambda _module: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        readiness_module,
+        "get_tts_provider",
+        lambda _provider: SimpleNamespace(
+            readiness=lambda: SimpleNamespace(
+                ready=True,
+                detail=None,
+                cached_files=30,
+                required_files=30,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        readiness_module,
+        "local_mlx_whisper_readiness",
+        lambda: SimpleNamespace(ready=True, detail=None),
+    )
+
+    readiness = readiness_module.local_audio_readiness(
+        tts_provider_id="kokoro",
+        stt_provider_id="local_mlx_whisper",
+    )
+
+    assert readiness.ready is True
+
+
+def test_local_audio_readiness_reports_kokoro_cache_count(monkeypatch) -> None:
+    monkeypatch.setattr(
+        readiness_module.importlib.util,
+        "find_spec",
+        lambda _module: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        readiness_module,
+        "get_tts_provider",
+        lambda _provider: SimpleNamespace(
+            readiness=lambda: SimpleNamespace(
+                ready=False,
+                detail="Kokoro model or voice files are missing.",
+                cached_files=0,
+                required_files=30,
+            )
+        ),
+    )
+
+    readiness = readiness_module.local_audio_readiness(
+        tts_provider_id="kokoro",
+        stt_provider_id="local_mlx_whisper",
+    )
+
+    assert readiness.ready is False
+    assert "0/30 cached" in readiness.detail

--- a/tests/test_setup_cli.py
+++ b/tests/test_setup_cli.py
@@ -1147,6 +1147,25 @@ def test_ensure_env_file_updates_existing_backend_only_when_requested(tmp_path) 
     assert "OPENBASE_CODING_BACKEND=claude_code" in content
 
 
+def test_ensure_env_file_removes_obsolete_offline_model_flags(tmp_path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "KEEP_ME=1\nHF_HUB_OFFLINE=1\nTRANSFORMERS_OFFLINE=1\n",
+        encoding="utf-8",
+    )
+
+    setup_cli._ensure_env_file(
+        str(env_file),
+        assembly_ai_api_key="",
+        cartesia_api_key="",
+    )
+
+    content = env_file.read_text(encoding="utf-8")
+    assert "KEEP_ME=1" in content
+    assert "HF_HUB_OFFLINE" not in content
+    assert "TRANSFORMERS_OFFLINE" not in content
+
+
 def test_ensure_thread_sync_exchange_dir_creates_syncthing_files(
     tmp_path, monkeypatch
 ) -> None:
@@ -1231,6 +1250,7 @@ def test_setup_configures_tailscale_serve(tmp_path, monkeypatch) -> None:
     (workspace / "cli").mkdir()
     (workspace / "multi.json").write_text("{}", encoding="utf-8")
     _patch_setup(monkeypatch, "ensure_backend_binary", lambda _backend: None)
+    _patch_setup(monkeypatch, "ensure_pinned_livekit_server", lambda: None)
     _patch_setup(monkeypatch, "_ensure_normal_codex_mcp", lambda _workspace_dir: None)
     _patch_setup(monkeypatch, "_ensure_normal_claude_mcp", lambda _workspace_dir: None)
     _patch_setup(monkeypatch, "_ensure_claude_auth_bridge", lambda **_kwargs: None)
@@ -1257,11 +1277,33 @@ def test_setup_configures_tailscale_serve(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(
         setup_cli, "_ensure_codex_home_dispatcher_config", lambda **_kwargs: None
     )
-    _patch_setup(monkeypatch, "_download_local_audio_models", lambda: None)
+    _patch_setup(monkeypatch, "set_dispatcher_service_tier", lambda _value: None)
+    _patch_setup(
+        monkeypatch,
+        "_ensure_local_audio_dependencies",
+        lambda _runtime: calls.append("local-dependencies"),
+    )
+    _patch_setup(
+        monkeypatch,
+        "_download_local_audio_models",
+        lambda: calls.append("local-models"),
+    )
+    _patch_setup(
+        monkeypatch,
+        "_ensure_local_audio_ready",
+        lambda: calls.append("local-ready"),
+    )
+    _patch_setup(monkeypatch, "_ensure_session_id_hook_script", lambda: None)
     monkeypatch.setattr(
         setup_cli, "_symlink_codex_home_skills", lambda _workspace_dir: None
     )
-    _patch_setup(monkeypatch, "_init_cli_workspace", lambda _workspace_dir: None)
+    _patch_setup(
+        monkeypatch,
+        "_init_cli_workspace",
+        lambda _workspace_dir, **kwargs: calls.append(
+            f"workspace-local-audio={kwargs['include_local_audio']}"
+        ),
+    )
     monkeypatch.setattr(
         setup_cli, "_ensure_codex_home_config", lambda *_args, **_kwargs: None
     )
@@ -1309,11 +1351,22 @@ def test_setup_configures_tailscale_serve(tmp_path, monkeypatch) -> None:
             str(env_file),
             "--backend",
             "claude-code",
+            "--audio-provider",
+            "local",
         ],
     )
 
     assert result.exit_code == 0, result.output
-    assert calls == ["thread-sync", "sounds", "normal-claude", "configure"]
+    assert calls == [
+        "thread-sync",
+        "sounds",
+        "normal-claude",
+        "workspace-local-audio=True",
+        "local-dependencies",
+        "local-models",
+        "local-ready",
+        "configure",
+    ]
 
 
 def test_ensure_local_audio_dependencies_installs_into_runtime_python(
@@ -1339,7 +1392,12 @@ def test_ensure_local_audio_dependencies_installs_into_runtime_python(
 
     setup_cli._ensure_local_audio_dependencies(runtime_package)
 
-    assert [command for command, _kwargs in commands][-1] == [
+    install_command, install_kwargs = next(
+        (command, kwargs)
+        for command, kwargs in commands
+        if command[1:4] == ["-m", "pip", "install"]
+    )
+    assert install_command == [
         str(python_path),
         "-m",
         "pip",
@@ -1347,21 +1405,87 @@ def test_ensure_local_audio_dependencies_installs_into_runtime_python(
         "--upgrade",
         *setup_cli.LOCAL_AUDIO_REQUIREMENTS,
     ]
+    assert install_kwargs["env"]["PIP_BREAK_SYSTEM_PACKAGES"] == "1"
+    assert install_kwargs["env"]["PATH"].split(os.pathsep)[0] == str(
+        python_path.parent
+    )
 
 
-def test_ensure_local_audio_dependencies_rejects_python_313(
+def test_ensure_local_audio_dependencies_installs_kokoro_spacy_model(
+    tmp_path, monkeypatch
+) -> None:
+    python_path = tmp_path / "python"
+    runtime_package = type("RuntimePackage", (), {"python_path": python_path})()
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append((command, kwargs))
+        if command[1:] == ["-c", f"import {setup_cli.LOCAL_AUDIO_SPACY_MODEL}"]:
+            return subprocess.CompletedProcess(command, 1)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    setup_cli._ensure_local_audio_dependencies(runtime_package)
+
+    model_command, model_kwargs = commands[-1]
+    assert model_command == [
+        str(python_path),
+        "-m",
+        "spacy",
+        "download",
+        setup_cli.LOCAL_AUDIO_SPACY_MODEL,
+    ]
+    assert model_kwargs["env"]["PIP_BREAK_SYSTEM_PACKAGES"] == "1"
+
+
+def test_ensure_local_audio_dependencies_supports_python_313(
     tmp_path, monkeypatch
 ) -> None:
     python_path = tmp_path / "python"
     runtime_package = type("RuntimePackage", (), {"python_path": python_path})()
 
+    commands = []
+
     def fake_run(command, **kwargs):
-        return subprocess.CompletedProcess(command, 0, stdout="3.13\n")
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    with pytest.raises(Exception, match="requires a Python 3.12"):
-        setup_cli._ensure_local_audio_dependencies(runtime_package)
+    setup_cli._ensure_local_audio_dependencies(runtime_package)
+
+    assert all("sys.version_info" not in command[-1] for command in commands)
+    assert "numba>=0.65.0" in setup_cli.LOCAL_AUDIO_REQUIREMENTS
+
+
+def test_init_cli_workspace_retains_local_audio_extra(tmp_path, monkeypatch) -> None:
+    workspace = tmp_path / "workspace"
+    cli_dir = workspace / "cli"
+    cli_dir.mkdir(parents=True)
+    commands = []
+
+    _patch_setup(monkeypatch, "which", lambda _name: "/usr/local/bin/uv")
+    _patch_setup(
+        monkeypatch,
+        "_download_livekit_model_files",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def fake_run(command, **kwargs):
+        commands.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0)
+
+    _patch_setup(monkeypatch, "subprocess", SimpleNamespace(run=fake_run))
+
+    setup_cli._init_cli_workspace(str(workspace), include_local_audio=True)
+
+    assert commands == [
+        (
+            ["/usr/local/bin/uv", "sync", "--extra", "local-audio"],
+            {"cwd": str(cli_dir), "check": True},
+        )
+    ]
 
 
 def test_workspace_skill_sources_supports_direct_skill_dirs(tmp_path) -> None:


### PR DESCRIPTION
Summary: Keeps the local-audio uv extra installed before model downloads; pins compatible NumPy and Numba; installs the Kokoro spaCy model; clears stale offline flags; validates the exact service runtime and both model caches; blocks room-token creation with an actionable local_audio_not_ready response; and updates the developer README and setup docs. Verification: frozen uv sync passed, Ruff passed, and 73 focused tests passed. Coordinated workspace PR: https://github.com/openbase-community/openbase-coder-workspace/pull/9