### PR TITLE
Add one-action voice approval lockdown

### DIFF
--- a/openbase_coder_cli/cli/__init__.py
+++ b/openbase_coder_cli/cli/__init__.py
@@ -24,6 +24,7 @@ from .computer_use import computer_use
 from .defaults import defaults
 from .desktop import desktop
 from .doctor import doctor
+from .lockdown import lockdown
 from .onboarding import onboarding
 from .plugins import plugins
 from .provision import provision
@@ -35,6 +36,7 @@ from .server import server
 from .services import services
 from .setup import setup
 from .super_agent_name import super_agent_name
+from .super_agents_mcp import super_agents_mcp
 from .sync import sync
 from .sync_workers import sync_workers
 from .user import exit_to_dispatch, user
@@ -70,6 +72,7 @@ main.add_command(setup)
 main.add_command(backend)
 main.add_command(services)
 main.add_command(doctor)
+main.add_command(lockdown)
 main.add_command(onboarding)
 main.add_command(desktop)
 main.add_command(login)
@@ -91,6 +94,7 @@ main.add_command(claude_chrome)
 main.add_command(computer_use)
 main.add_command(routines)
 main.add_command(super_agent_name)
+main.add_command(super_agents_mcp)
 main.add_command(sync)
 main.add_command(sync_workers)
 main.add_command(defaults)

--- a/openbase_coder_cli/cli/auth.py
+++ b/openbase_coder_cli/cli/auth.py
@@ -311,6 +311,9 @@ def login() -> None:
 @click.command()
 def logout() -> None:
     """Log out and clear stored tokens."""
+    from openbase_coder_cli.voice_lockdown import get_voice_lockdown_broker
+
+    get_voice_lockdown_broker().revoke_all(reason="logout")
     if AUTH_JSON_PATH.is_file():
         AUTH_JSON_PATH.unlink()
         if MACHINE_TOKEN_JSON_PATH.is_file():

--- a/openbase_coder_cli/cli/lockdown.py
+++ b/openbase_coder_cli/cli/lockdown.py
@@ -1,0 +1,150 @@
+"""Local-only management commands for one-action voice lockdown."""
+
+from __future__ import annotations
+
+import base64
+import json
+import secrets
+
+import click
+
+from openbase_coder_cli.services.restart import RestartRequest, schedule_restart
+from openbase_coder_cli.voice_lockdown.broker import (
+    LockdownDeniedError,
+    get_voice_lockdown_broker,
+    require_safe_baseline,
+)
+from openbase_coder_cli.voice_lockdown.keychain import KeychainRecord
+from openbase_coder_cli.voice_lockdown.policy import check_managed_mcp_registration
+from openbase_coder_cli.voice_lockdown.verifier import (
+    derive_verifier,
+    validate_new_phrase,
+    verify_phrase,
+)
+
+
+def _new_phrase() -> str:
+    value = click.prompt("New safe phrase", hide_input=True, confirmation_prompt=True)
+    try:
+        return validate_new_phrase(value)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+def _require_record_and_phrase():
+    broker = get_voice_lockdown_broker()
+    _health, record = broker.health()
+    if record is None:
+        raise click.ClickException("Voice lockdown has not been configured safely.")
+    phrase = click.prompt("Safe phrase", hide_input=True)
+    if not verify_phrase(phrase, salt_b64=record.salt, verifier_b64=record.verifier):
+        raise click.ClickException("Safe phrase did not match.")
+    return broker, record
+
+
+def _schedule_security_restart() -> None:
+    try:
+        schedule_restart(RestartRequest(recreate_dispatcher=True, delay_seconds=1.0), warn=False)
+    except Exception as exc:
+        raise click.ClickException(
+            "Lockdown state changed, but managed services could not be restarted. "
+            "Execution remains fail closed; run 'openbase-coder restart --recreate-dispatcher'."
+        ) from exc
+
+
+@click.group("lockdown")
+def lockdown() -> None:
+    """Manage one-action voice safe-phrase authorization."""
+
+
+@lockdown.command("setup")
+def setup_lockdown() -> None:
+    """Create the Keychain-backed verifier without enabling lockdown."""
+    if not click.get_text_stream("stdin").isatty():
+        raise click.ClickException("Lockdown setup requires an interactive local terminal.")
+    broker = get_voice_lockdown_broker()
+    health, existing = broker.health()
+    if existing is not None or health == "indeterminate":
+        raise click.ClickException("Lockdown is already configured or needs repair; use rotate/status.")
+    phrase = _new_phrase()
+    salt = secrets.token_bytes(16)
+    record = KeychainRecord(
+        enabled=False,
+        salt=base64.b64encode(salt).decode("ascii"),
+        verifier=derive_verifier(phrase, salt),
+        audit_key=base64.b64encode(secrets.token_bytes(32)).decode("ascii"),
+    )
+    broker.set_configuration(record, event_type="configured")
+    click.echo("Voice lockdown was configured in macOS Keychain and remains disabled.")
+
+
+@lockdown.command("enable")
+def enable_lockdown() -> None:
+    """Enable fail-closed, one-approval safe-phrase authorization."""
+    broker, record = _require_record_and_phrase()
+    try:
+        check = require_safe_baseline()
+    except LockdownDeniedError as exc:
+        raise click.ClickException(f"Refusing to enable lockdown because the coding baseline is unsafe: {exc}") from exc
+    managed = check_managed_mcp_registration()
+    if not managed.ready:
+        raise click.ClickException(
+            "Refusing to enable lockdown until Openbase-managed MCP registrations are refreshed: "
+            + "; ".join(managed.reasons)
+        )
+    broker.revoke_all(reason="enable")
+    broker.set_configuration(
+        KeychainRecord(True, record.salt, record.verifier, record.audit_key),
+        event_type="enabled",
+    )
+    _schedule_security_restart()
+    click.echo(
+        "Voice lockdown enabled for one pending approval at a time. "
+        f"Safe baseline verified for: {', '.join(check.configured_backends)}."
+    )
+
+
+@lockdown.command("disable")
+def disable_lockdown() -> None:
+    """Disable lockdown after local phrase verification."""
+    broker, record = _require_record_and_phrase()
+    broker.revoke_all(reason="disable")
+    broker.set_configuration(
+        KeychainRecord(False, record.salt, record.verifier, record.audit_key),
+        event_type="disabled",
+    )
+    _schedule_security_restart()
+    click.echo("Voice lockdown disabled; all outstanding capabilities were revoked.")
+
+
+@lockdown.command("rotate")
+def rotate_lockdown() -> None:
+    """Replace the phrase without ever returning it through an API."""
+    broker, record = _require_record_and_phrase()
+    phrase = _new_phrase()
+    salt = secrets.token_bytes(16)
+    broker.revoke_all(reason="phrase_rotation")
+    broker.set_configuration(
+        KeychainRecord(
+            record.enabled,
+            base64.b64encode(salt).decode("ascii"),
+            derive_verifier(phrase, salt),
+            record.audit_key,
+        ),
+        event_type="phrase_rotated",
+    )
+    _schedule_security_restart()
+    click.echo("Voice-lockdown phrase rotated; all outstanding capabilities were revoked.")
+
+
+@lockdown.command("status")
+def lockdown_status() -> None:
+    """Show non-secret lockdown state."""
+    click.echo(json.dumps(get_voice_lockdown_broker().status(), indent=2, sort_keys=True))
+
+
+@lockdown.command("audit")
+@click.option("--limit", type=click.IntRange(1, 200), default=50, show_default=True)
+def lockdown_audit(limit: int) -> None:
+    """Show bounded, redacted lockdown audit events."""
+    click.echo(json.dumps(get_voice_lockdown_broker().recent_audit(limit=limit), indent=2, sort_keys=True))

--- a/openbase_coder_cli/cli/routines.py
+++ b/openbase_coder_cli/cli/routines.py
@@ -9,6 +9,11 @@ from typing import Any
 
 import click
 from super_agents.app_server_client import CodexAppServerClient
+from super_agents.execution_control import configure_execution_controls
+
+from openbase_coder_cli.voice_lockdown.execution_controls import (
+    managed_execution_controls,
+)
 
 REASONING_EFFORTS = ("low", "medium", "high", "xhigh")
 SANDBOX_TYPES = ("readOnly", "workspaceWrite", "dangerFullAccess")
@@ -25,6 +30,7 @@ def _json_echo(value: dict[str, Any]) -> None:
 def _run_client(coro):
     async def runner():
         client = CodexAppServerClient()
+        configure_execution_controls(client, **managed_execution_controls())
         try:
             return await coro(client)
         finally:

--- a/openbase_coder_cli/cli/setup/codex.py
+++ b/openbase_coder_cli/cli/setup/codex.py
@@ -355,6 +355,14 @@ def _super_agents_mcp_command(workspace_dir: Path) -> tuple[Path, list[str]]:
     # An empty workspace_dir means standalone mode; never emit paths relative
     # to whatever directory setup happened to run from.
     has_workspace = bool(str(workspace_dir).strip()) and str(workspace_dir) != "."
+    managed_candidates = (
+        workspace_dir / ".venv" / "bin" / "openbase-coder",
+        workspace_dir / "cli" / ".venv" / "bin" / "openbase-coder",
+    )
+    if has_workspace:
+        for candidate in managed_candidates:
+            if candidate.is_file():
+                return candidate, ["super-agents-mcp"]
     candidates = (
         workspace_dir / ".venv" / "bin" / SUPER_AGENTS_MCP_COMMAND,
         workspace_dir / "cli" / ".venv" / "bin" / SUPER_AGENTS_MCP_COMMAND,
@@ -366,6 +374,9 @@ def _super_agents_mcp_command(workspace_dir: Path) -> tuple[Path, list[str]]:
 
     runtime_package = current_runtime_package()
     if runtime_package is not None:
+        managed_command = runtime_package.python_path.parent / "openbase-coder"
+        if managed_command.is_file():
+            return stable_package_path(managed_command), ["super-agents-mcp"]
         bundled_command = runtime_package.python_path.parent / SUPER_AGENTS_MCP_COMMAND
         if bundled_command.is_file():
             # Persisted into MCP configs: must survive release rotation.

--- a/openbase_coder_cli/cli/super_agents_mcp.py
+++ b/openbase_coder_cli/cli/super_agents_mcp.py
@@ -1,0 +1,20 @@
+"""Openbase-managed Super Agents MCP entry point with mandatory controls."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+from super_agents.backend_clients import multi_client_from_environment
+from super_agents.mcp_server import run_stdio
+
+from openbase_coder_cli.voice_lockdown.execution_controls import (
+    managed_execution_controls,
+)
+
+
+@click.command("super-agents-mcp", hidden=True)
+def super_agents_mcp() -> None:
+    """Run Super Agents with Openbase's required execution controls."""
+    client = multi_client_from_environment(**managed_execution_controls())
+    asyncio.run(run_stdio(client))

--- a/openbase_coder_cli/livekit_agent/livekit.py
+++ b/openbase_coder_cli/livekit_agent/livekit.py
@@ -129,6 +129,7 @@ from openbase_coder_cli.livekit_agent.config import (  # noqa: F401
     _read_instruction_file,
     load_direct_livekit_developer_instructions,
 )
+from openbase_coder_cli.livekit_agent.lockdown_stt import VoiceLockdownSTT
 from openbase_coder_cli.livekit_agent.logging_utils import (  # noqa: F401
     _event_text_hash,
     _frame_duration_ms,
@@ -233,6 +234,7 @@ from openbase_coder_cli.tts_providers import (  # noqa: F401
     OPENBASE_CLOUD_TTS_PROVIDER_ID,
     get_tts_provider,
 )
+from openbase_coder_cli.voice_lockdown import get_voice_lockdown_broker
 
 logger = logging.getLogger(__name__)
 
@@ -332,7 +334,14 @@ def _build_voice_backend_client(*, persist_thread: bool) -> SuperAgentsLiveKitCl
 _shared_voice_backend_client = _build_voice_backend_client(persist_thread=True)
 
 
-def _build_stt(vad_model=None):
+def _build_stt(
+    vad_model=None,
+    *,
+    lockdown_broker=None,
+    lockdown_room_sid: str = "",
+    lockdown_participant_identity: str = "",
+    lockdown_outcome=None,
+):
     stt_provider = selected_stt_provider_id()
     if stt_provider == DEEPGRAM_STT_PROVIDER_ID:
         logger.info("Using Deepgram STT")
@@ -357,6 +366,16 @@ def _build_stt(vad_model=None):
     else:
         raise ValueError(f"Unsupported STT provider={stt_provider!r}")
 
+    # This must be the innermost wrapper: armed phrase candidates are removed
+    # before scoring, verbose logging, deduplication, chat history, or an LLM.
+    if lockdown_broker is not None:
+        stt = VoiceLockdownSTT(
+            stt,
+            broker=lockdown_broker,
+            room_sid=lockdown_room_sid,
+            participant_identity=lockdown_participant_identity,
+            on_outcome=lockdown_outcome,
+        )
     stt = BrainScoreSTT(stt) if _brain_score_enabled() else stt
     stt = LoggingSTT(stt) if LIVEKIT_VERBOSE_LOGGING else stt
     return FinalTranscriptDedupSTT(stt)
@@ -809,9 +828,36 @@ async def _start_voice_session(
     session_vad = _diagnostic_vad(ctx.proc.userdata["vad"])
     turn_signal_tracker = VoiceTurnSignalTracker()
 
+    room_sid = await _room_sid(ctx.room)
+    remote_participants = list(ctx.room.remote_participants.values())
+    participant_identity = (
+        str(remote_participants[0].identity or "")
+        if len(remote_participants) == 1
+        else ""
+    )
+    session_holder: dict[str, AgentSession] = {}
+
+    def lockdown_outcome(outcome: str) -> None:
+        session_for_notice = session_holder.get("session")
+        if session_for_notice is None:
+            return
+        notices = {
+            "authorized": "Authorized for this action once.",
+            "mismatch": "That phrase did not match.",
+            "rate_limited": "Too many attempts. Safe phrase authorization is temporarily paused.",
+        }
+        if notice := notices.get(outcome):
+            session_for_notice.say(notice)
+
     # Set up a voice AI pipeline
     session = AgentSession(
-        stt=_build_stt(session_vad),
+        stt=_build_stt(
+            session_vad,
+            lockdown_broker=get_voice_lockdown_broker(),
+            lockdown_room_sid=room_sid,
+            lockdown_participant_identity=participant_identity,
+            lockdown_outcome=lockdown_outcome,
+        ),
         llm=CodexLiveKitLLM(
             voice_router,
             turn_signal_tracker=turn_signal_tracker,
@@ -826,6 +872,7 @@ async def _start_voice_session(
         vad=session_vad,
         preemptive_generation=False,
     )
+    session_holder["session"] = session
     session_diagnostic_handlers = _register_session_diagnostics(
         session,
         voice_router,
@@ -1002,6 +1049,7 @@ async def livekit_agent(ctx: JobContext):
             _packet_hash(data_packet),
         )
         if route_command.action == "exit_to_dispatch":
+            get_voice_lockdown_broker().revoke_all(reason="voice_route_exit")
             voice_router.exit_to_dispatch()
             announcer_queue.enqueue(
                 AnnouncerMessage(
@@ -1015,6 +1063,7 @@ async def livekit_agent(ctx: JobContext):
                     "Ignoring incomplete LiveKit voice route transfer command"
                 )
                 return
+            get_voice_lockdown_broker().revoke_all(reason="voice_route_transfer")
             asyncio.create_task(
                 _transfer_voice_route(
                     voice_router,
@@ -1031,6 +1080,7 @@ async def livekit_agent(ctx: JobContext):
     ctx.room.on("data_received", on_data_received)
 
     async def close_announcer_queue(*_args) -> None:
+        get_voice_lockdown_broker().revoke_all(reason="voice_session_closed")
         if subscription_check_task is not None:
             subscription_check_task.cancel()
         ctx.room.off("data_received", on_data_received)

--- a/openbase_coder_cli/livekit_agent/lockdown_stt.py
+++ b/openbase_coder_cli/livekit_agent/lockdown_stt.py
@@ -1,0 +1,166 @@
+"""STT boundary that consumes armed safe-phrase utterances before logging."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+from livekit.agents import stt as livekit_stt
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN
+
+from openbase_coder_cli.voice_lockdown.broker import VoiceLockdownBroker
+
+
+class VoiceLockdownSTT(livekit_stt.STT):
+    """Wrap the raw provider; challenge transcripts never reach outer wrappers."""
+
+    def __init__(
+        self,
+        wrapped: livekit_stt.STT,
+        *,
+        broker: VoiceLockdownBroker,
+        room_sid: str,
+        participant_identity: str,
+        on_outcome: Callable[[str], None] | None = None,
+    ) -> None:
+        super().__init__(capabilities=wrapped.capabilities)
+        self._wrapped = wrapped
+        self._broker = broker
+        self._room_sid = room_sid
+        self._participant_identity = participant_identity
+        self._on_outcome = on_outcome or (lambda _outcome: None)
+        self._wrapped.on("metrics_collected", lambda metrics: self.emit("metrics_collected", metrics))
+        self._wrapped.on("error", lambda error: self.emit("error", error))
+
+    @property
+    def label(self) -> str:
+        return self._wrapped.label
+
+    @property
+    def model(self) -> str:
+        return self._wrapped.model
+
+    @property
+    def provider(self) -> str:
+        return self._wrapped.provider
+
+    async def _recognize_impl(self, buffer, *, language=NOT_GIVEN, conn_options=DEFAULT_API_CONNECT_OPTIONS):
+        event = await self._wrapped.recognize(buffer, language=language, conn_options=conn_options)
+        if self._armed():
+            raise RuntimeError("Offline transcription is disabled while a safe-phrase challenge is armed.")
+        return event
+
+    def stream(self, *, language=NOT_GIVEN, conn_options=DEFAULT_API_CONNECT_OPTIONS):
+        return VoiceLockdownStream(
+            self._wrapped.stream(language=language, conn_options=conn_options),
+            broker=self._broker,
+            room_sid=self._room_sid,
+            participant_identity=self._participant_identity,
+            on_outcome=self._on_outcome,
+        )
+
+    def _armed(self) -> bool:
+        return bool(
+            self._room_sid
+            and self._participant_identity
+            and self._broker.is_armed(
+                room_sid=self._room_sid,
+                participant_identity=self._participant_identity,
+            )
+        )
+
+    def prewarm(self) -> None:
+        self._wrapped.prewarm()
+
+    async def aclose(self) -> None:
+        await self._wrapped.aclose()
+
+
+class VoiceLockdownStream:
+    def __init__(self, stream, *, broker, room_sid, participant_identity, on_outcome) -> None:
+        self._stream = stream
+        self._broker = broker
+        self._room_sid = room_sid
+        self._participant_identity = participant_identity
+        self._on_outcome = on_outcome
+        self._suppress_transcripts_until = 0.0
+
+    @property
+    def start_time_offset(self):
+        return self._stream.start_time_offset
+
+    @start_time_offset.setter
+    def start_time_offset(self, value):
+        self._stream.start_time_offset = value
+
+    @property
+    def start_time(self):
+        return self._stream.start_time
+
+    @start_time.setter
+    def start_time(self, value):
+        self._stream.start_time = value
+
+    def push_frame(self, frame) -> None:
+        self._stream.push_frame(frame)
+
+    def flush(self) -> None:
+        self._stream.flush()
+
+    def end_input(self) -> None:
+        self._stream.end_input()
+
+    async def aclose(self) -> None:
+        await self._stream.aclose()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        while True:
+            event = await self._stream.__anext__()
+            if event.type == livekit_stt.SpeechEventType.START_OF_SPEECH:
+                self._suppress_transcripts_until = 0.0
+            armed = bool(
+                self._room_sid
+                and self._participant_identity
+                and self._broker.is_armed(
+                    room_sid=self._room_sid,
+                    participant_identity=self._participant_identity,
+                )
+            )
+            transcript_event = event.type in {
+                livekit_stt.SpeechEventType.INTERIM_TRANSCRIPT,
+                livekit_stt.SpeechEventType.FINAL_TRANSCRIPT,
+            }
+            if not armed and not (
+                transcript_event and time.monotonic() < self._suppress_transcripts_until
+            ):
+                return event
+            if event.type == livekit_stt.SpeechEventType.FINAL_TRANSCRIPT:
+                if armed:
+                    transcript = event.alternatives[0].text if event.alternatives else ""
+                    outcome = self._broker.verify_final_utterance(
+                        transcript,
+                        room_sid=self._room_sid,
+                        participant_identity=self._participant_identity,
+                    )
+                    self._on_outcome(outcome)
+                # Some providers emit an unformatted/formatted final pair.
+                # The outer deduper never sees the consumed first copy, so
+                # retain a short local suppression window until new speech.
+                self._suppress_transcripts_until = time.monotonic() + 3.0
+            # Suppress both interim and final challenge speech. Other audio
+            # lifecycle events contain no transcript and can pass through.
+            if event.type not in {
+                livekit_stt.SpeechEventType.INTERIM_TRANSCRIPT,
+                livekit_stt.SpeechEventType.FINAL_TRANSCRIPT,
+            }:
+                return event
+
+    async def __aenter__(self):
+        await self._stream.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc, exc_tb) -> None:
+        await self._stream.__aexit__(exc_type, exc, exc_tb)

--- a/openbase_coder_cli/livekit_agent/super_agents_client_threads.py
+++ b/openbase_coder_cli/livekit_agent/super_agents_client_threads.py
@@ -200,6 +200,10 @@ class SuperAgentsClientThreadsMixin:
         from super_agents.app_server_client import CodexAppServerClient
         from super_agents.backend_clients import backend_from_environment
 
+        from openbase_coder_cli.voice_lockdown.execution_controls import (
+            managed_execution_controls,
+        )
+
         try:
             from openbase_coder_cli.livekit_agent.config import _load_openbase_env
 
@@ -211,8 +215,8 @@ class SuperAgentsClientThreadsMixin:
         if execution_backend == CLAUDE_CODE_BACKEND:
             from super_agents.claude_sdk import ClaudeAgentSdkClient
 
-            return ClaudeAgentSdkClient()
-        return CodexAppServerClient()
+            return ClaudeAgentSdkClient(**managed_execution_controls())
+        return CodexAppServerClient(**managed_execution_controls())
 
     def _register_backend_callback(self) -> None:
         register = getattr(self._backend_client, "register_permission_callback", None)

--- a/openbase_coder_cli/openbase_coder_cli_app/auth.py
+++ b/openbase_coder_cli/openbase_coder_cli_app/auth.py
@@ -78,5 +78,8 @@ def auth_refresh_jwt(request):
 @permission_classes([AllowAny])
 def auth_logout(request):
     """Clear the locally stored JWT tokens."""
+    from openbase_coder_cli.voice_lockdown import get_voice_lockdown_broker
+
+    get_voice_lockdown_broker().revoke_all(reason="logout")
     get_token_manager().clear()
     return Response({"success": True}, status=status.HTTP_200_OK)

--- a/openbase_coder_cli/openbase_coder_cli_app/lockdown.py
+++ b/openbase_coder_cli/openbase_coder_cli_app/lockdown.py
@@ -1,0 +1,102 @@
+"""Authenticated, non-secret voice-lockdown status and challenge API."""
+
+from __future__ import annotations
+
+from asgiref.sync import async_to_sync
+from rest_framework import serializers, status
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from super_agents.approval_redaction import redact_approval_payload
+
+from openbase_coder_cli.thread_sync.session_manager import get_session_manager
+from openbase_coder_cli.voice_lockdown.broker import (
+    ApprovalScope,
+    LockdownDeniedError,
+    canonical_action_digest,
+    get_voice_lockdown_broker,
+)
+
+
+class LockdownChallengeSerializer(serializers.Serializer):
+    requestId = serializers.CharField(max_length=256)
+    roomSid = serializers.CharField(max_length=256)
+    participantIdentity = serializers.CharField(max_length=256)
+
+
+@api_view(["GET"])
+def lockdown_status(request):
+    """Return only non-secret health, baseline, and challenge metadata."""
+    return Response(get_voice_lockdown_broker().status(), status=status.HTTP_200_OK)
+
+
+@api_view(["POST"])
+def lockdown_challenges(request):
+    """Arm phrase capture for one authoritative pending approval."""
+    serializer = LockdownChallengeSerializer(data=request.data)
+    serializer.is_valid(raise_exception=True)
+    request_id = serializer.validated_data["requestId"]
+    manager = get_session_manager()
+    pending = async_to_sync(manager.list_approval_requests)()
+    approval = next((item for item in pending if str(item.get("id")) == request_id), None)
+    if approval is None:
+        return Response({"error": "The approval request is not pending."}, status=status.HTTP_404_NOT_FOUND)
+    params = approval.get("params") if isinstance(approval.get("params"), dict) else {}
+    tool_name = str(params.get("toolName") or params.get("name") or approval.get("method") or "")
+    action_input = {
+        key: value
+        for key, value in params.items()
+        if key
+        not in {
+            "approvalExpiresAt",
+            "approvalActionDigest",
+            "approvalManagedBy",
+            "approvalOwnerId",
+            "approvalOwnerPid",
+            "backend",
+            "description",
+            "name",
+            "threadId",
+            "title",
+            "toolCallId",
+            "toolName",
+            "turnId",
+        }
+    }
+    action = {
+        "method": str(approval.get("method") or ""),
+        "tool": tool_name,
+        "input": action_input,
+    }
+    scope = ApprovalScope(
+        backend=str(params.get("backend") or "codex"),
+        request_id=request_id,
+        thread_id=str(params.get("threadId") or ""),
+        turn_id=str(params.get("turnId") or ""),
+        tool_call_id=str(params.get("toolCallId") or params.get("itemId") or ""),
+        tool_name=tool_name,
+        action_digest=str(params.get("approvalActionDigest") or canonical_action_digest(action)),
+        room_sid=serializer.validated_data["roomSid"],
+        participant_identity=serializer.validated_data["participantIdentity"],
+    )
+    try:
+        challenge = get_voice_lockdown_broker().create_challenge(
+            scope,
+            action_summary=str(
+                redact_approval_payload(params.get("description") or params.get("name") or tool_name)
+            ),
+        )
+    except LockdownDeniedError as exc:
+        return Response({"error": str(exc)}, status=status.HTTP_409_CONFLICT)
+    return Response({"challenge": challenge}, status=status.HTTP_201_CREATED)
+
+
+@api_view(["DELETE"])
+def lockdown_challenge_detail(request, challenge_id):
+    """Cancel one challenge; there is intentionally no phrase submission API."""
+    try:
+        cancelled = get_voice_lockdown_broker().cancel_challenge(challenge_id)
+    except LockdownDeniedError as exc:
+        return Response({"error": str(exc)}, status=status.HTTP_409_CONFLICT)
+    if not cancelled:
+        return Response({"error": "Challenge is no longer pending."}, status=status.HTTP_404_NOT_FOUND)
+    return Response({"cancelled": True}, status=status.HTTP_200_OK)

--- a/openbase_coder_cli/openbase_coder_cli_app/urls.py
+++ b/openbase_coder_cli/openbase_coder_cli_app/urls.py
@@ -62,6 +62,9 @@ from openbase_coder_cli.openbase_coder_cli_app.views import (
     livekit_voice_route_exit,
     livekit_voice_route_transfer,
     local_stt_download,
+    lockdown_challenge_detail,
+    lockdown_challenges,
+    lockdown_status,
     onboarding_cloud_state,
     onboarding_status,
     openbase_restart,
@@ -175,6 +178,13 @@ urlpatterns = [
         name="thread-steer-turn",
     ),
     path("approval-requests/", approval_requests, name="approval-requests"),
+    path("lockdown/", lockdown_status, name="lockdown-status"),
+    path("lockdown/challenges/", lockdown_challenges, name="lockdown-challenges"),
+    path(
+        "lockdown/challenges/<str:challenge_id>/",
+        lockdown_challenge_detail,
+        name="lockdown-challenge-detail",
+    ),
     path(
         "approval-requests/<str:request_id>/",
         approval_request_detail,

--- a/openbase_coder_cli/openbase_coder_cli_app/views.py
+++ b/openbase_coder_cli/openbase_coder_cli_app/views.py
@@ -54,6 +54,11 @@ from openbase_coder_cli.openbase_coder_cli_app.livekit import (
     livekit_voice_route_exit,
     livekit_voice_route_transfer,
 )
+from openbase_coder_cli.openbase_coder_cli_app.lockdown import (
+    lockdown_challenge_detail,
+    lockdown_challenges,
+    lockdown_status,
+)
 from openbase_coder_cli.openbase_coder_cli_app.model_settings import (
     backend_model_settings,  # noqa: F401
 )
@@ -293,6 +298,9 @@ __all__ = [
     "ios_app_control",
     "kokoro_tts_download",
     "keep_awake_settings",
+    "lockdown_challenge_detail",
+    "lockdown_challenges",
+    "lockdown_status",
     "launchctl_ignored_settings",
     "launchctl_service_action",
     "launchctl_services_list",

--- a/openbase_coder_cli/thread_sync/session_manager_base.py
+++ b/openbase_coder_cli/thread_sync/session_manager_base.py
@@ -200,7 +200,11 @@ class _OpenbaseSuperAgentsClient(CodexAppServerClient):
     def __init__(
         self, manager: "CodexAppServerSessionManager", ws_url: str | None
     ) -> None:
-        super().__init__(ws_url=ws_url)
+        from openbase_coder_cli.voice_lockdown.execution_controls import (
+            managed_execution_controls,
+        )
+
+        super().__init__(ws_url=ws_url, **managed_execution_controls())
         self._manager = manager
 
     async def start_managed_server(self) -> None:
@@ -233,7 +237,11 @@ def _default_client_for_execution_backend(
     if execution_backend == CLAUDE_CODE_BACKEND:
         from super_agents.claude_sdk import ClaudeAgentSdkClient
 
-        return ClaudeAgentSdkClient()
+        from openbase_coder_cli.voice_lockdown.execution_controls import (
+            managed_execution_controls,
+        )
+
+        return ClaudeAgentSdkClient(**managed_execution_controls())
     return _OpenbaseSuperAgentsClient(manager, ws_url)
 
 

--- a/openbase_coder_cli/voice_lockdown/__init__.py
+++ b/openbase_coder_cli/voice_lockdown/__init__.py
@@ -1,0 +1,5 @@
+"""Fail-closed, per-approval voice authorization for Openbase Coder."""
+
+from .broker import VoiceLockdownBroker, get_voice_lockdown_broker
+
+__all__ = ["VoiceLockdownBroker", "get_voice_lockdown_broker"]

--- a/openbase_coder_cli/voice_lockdown/audit.py
+++ b/openbase_coder_cli/voice_lockdown/audit.py
@@ -1,0 +1,88 @@
+"""HMAC-chained, redacted audit storage for voice lockdown."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import sqlite3
+import threading
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from .keychain import KeychainRecord
+
+
+class LockdownAuditLog:
+    def __init__(
+        self,
+        *,
+        connect: Callable[[], sqlite3.Connection],
+        clock: Callable[[], float],
+        lock: threading.RLock,
+    ) -> None:
+        self._connect = connect
+        self._clock = clock
+        self._lock = lock
+
+    def append(self, event_type: str, detail: dict[str, Any], *, record: KeychainRecord) -> None:
+        created_at = self._clock()
+        event_id = f"vla_{uuid.uuid4().hex}"
+        detail_json = json.dumps(detail, separators=(",", ":"), sort_keys=True)
+        audit_key = base64.b64decode(record.audit_key)
+        with self._lock, self._connect() as db:
+            db.execute("BEGIN IMMEDIATE")
+            previous = db.execute(
+                "SELECT event_mac FROM audit_events ORDER BY sequence DESC LIMIT 1"
+            ).fetchone()
+            previous_mac = previous["event_mac"] if previous else ""
+            message = f"{event_id}|{created_at:.6f}|{event_type}|{detail_json}|{previous_mac}".encode()
+            event_mac = hmac.new(audit_key, message, hashlib.sha256).hexdigest()
+            db.execute(
+                """INSERT INTO audit_events(event_id, created_at, event_type, detail_json, previous_mac, event_mac)
+                VALUES(?, ?, ?, ?, ?, ?)""",
+                (event_id, created_at, event_type, detail_json, previous_mac, event_mac),
+            )
+            db.commit()
+
+    def recent(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        with self._connect() as db:
+            rows = db.execute(
+                "SELECT sequence, event_id, created_at, event_type, detail_json FROM audit_events ORDER BY sequence DESC LIMIT ?",
+                (max(1, min(limit, 200)),),
+            ).fetchall()
+        return [
+            {
+                "sequence": row["sequence"],
+                "eventId": row["event_id"],
+                "createdAt": row["created_at"],
+                "eventType": row["event_type"],
+                "detail": json.loads(row["detail_json"]),
+            }
+            for row in rows
+        ]
+
+    def integrity_valid(self, record: KeychainRecord) -> bool:
+        try:
+            audit_key = base64.b64decode(record.audit_key, validate=True)
+            with self._connect() as db:
+                rows = db.execute("SELECT * FROM audit_events ORDER BY sequence").fetchall()
+        except (ValueError, sqlite3.DatabaseError):
+            return False
+        if not rows:
+            return False
+        previous_mac = ""
+        for row in rows:
+            if row["previous_mac"] != previous_mac:
+                return False
+            message = (
+                f"{row['event_id']}|{float(row['created_at']):.6f}|{row['event_type']}|"
+                f"{row['detail_json']}|{previous_mac}"
+            ).encode()
+            expected = hmac.new(audit_key, message, hashlib.sha256).hexdigest()
+            if not hmac.compare_digest(expected, row["event_mac"]):
+                return False
+            previous_mac = row["event_mac"]
+        return True

--- a/openbase_coder_cli/voice_lockdown/broker.py
+++ b/openbase_coder_cli/voice_lockdown/broker.py
@@ -1,0 +1,551 @@
+"""Persistent challenge broker with atomic, one-use approval leases."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import platform
+import secrets
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from super_agents.execution_control import ApprovalAuthorizationRequest
+
+from openbase_coder_cli.paths import OPENBASE_BASE_DIR
+
+from .audit import LockdownAuditLog
+from .keychain import (
+    KeychainCorruptError,
+    KeychainRecord,
+    KeychainUnavailableError,
+    MacOSKeychain,
+)
+from .policy import BaselineCheck, check_managed_mcp_registration, check_safe_baseline
+from .verifier import verify_phrase
+
+CHALLENGE_TTL_SECONDS = 120.0
+CAPABILITY_TTL_SECONDS = 30.0
+MAX_ATTEMPTS = 3
+COOLDOWN_SECONDS = 300.0
+DEFAULT_DB_PATH = OPENBASE_BASE_DIR / "security" / "voice-lockdown.sqlite3"
+
+
+class LockdownDeniedError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalScope:
+    backend: str
+    request_id: str
+    thread_id: str
+    turn_id: str
+    tool_call_id: str
+    tool_name: str
+    action_digest: str
+    room_sid: str
+    participant_identity: str
+
+
+def canonical_action_digest(action: Any) -> str:
+    encoded = json.dumps(
+        action,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class VoiceLockdownBroker:
+    def __init__(
+        self,
+        *,
+        db_path: str | Path = DEFAULT_DB_PATH,
+        keychain: MacOSKeychain | None = None,
+        clock: Any = time.time,
+    ) -> None:
+        self.db_path = Path(db_path)
+        self.keychain = keychain or MacOSKeychain()
+        self.clock = clock
+        self._lock = threading.RLock()
+        self._initialize_db()
+        self.audit = LockdownAuditLog(connect=self._connect, clock=self.clock, lock=self._lock)
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.db_path, timeout=5, isolation_level=None)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def _initialize_db(self) -> None:
+        self.db_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(self.db_path.parent, 0o700)
+        with self._connect() as db:
+            db.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS metadata (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS challenges (
+                    id TEXT PRIMARY KEY,
+                    scope_json TEXT NOT NULL,
+                    action_summary TEXT NOT NULL,
+                    challenge_mac TEXT,
+                    created_at REAL NOT NULL,
+                    expires_at REAL NOT NULL,
+                    attempts_remaining INTEGER NOT NULL,
+                    state TEXT NOT NULL,
+                    capability_id TEXT,
+                    capability_mac TEXT,
+                    capability_expires_at REAL,
+                    consumed_at REAL
+                );
+                CREATE TABLE IF NOT EXISTS cooldowns (
+                    participant_hash TEXT PRIMARY KEY,
+                    until_at REAL NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS audit_events (
+                    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                    event_id TEXT UNIQUE NOT NULL,
+                    created_at REAL NOT NULL,
+                    event_type TEXT NOT NULL,
+                    detail_json TEXT NOT NULL,
+                    previous_mac TEXT NOT NULL,
+                    event_mac TEXT NOT NULL
+                );
+                """
+            )
+            columns = {row[1] for row in db.execute("PRAGMA table_info(challenges)")}
+            if "capability_id" not in columns:
+                db.execute("ALTER TABLE challenges ADD COLUMN capability_id TEXT")
+            if "capability_mac" not in columns:
+                db.execute("ALTER TABLE challenges ADD COLUMN capability_mac TEXT")
+            if "challenge_mac" not in columns:
+                db.execute("ALTER TABLE challenges ADD COLUMN challenge_mac TEXT")
+        os.chmod(self.db_path, 0o600)
+
+    def _record(self) -> KeychainRecord | None:
+        return self.keychain.read()
+
+    def health(self) -> tuple[str, KeychainRecord | None]:
+        try:
+            with self._connect() as db:
+                configured = db.execute(
+                    "SELECT value FROM metadata WHERE key = 'configured'"
+                ).fetchone()
+        except sqlite3.DatabaseError:
+            return "indeterminate", None
+        if configured is None and platform.system() != "Darwin":
+            return "unconfigured", None
+        try:
+            record = self._record()
+        except (KeychainUnavailableError, KeychainCorruptError):
+            return "indeterminate", None
+        if record is not None:
+            if configured is None or not self.audit.integrity_valid(record):
+                return "indeterminate", None
+            return ("ready" if record.enabled else "disabled"), record
+        return ("indeterminate" if configured else "unconfigured"), None
+
+    def status(self) -> dict[str, Any]:
+        health, record = self.health()
+        baseline = check_safe_baseline()
+        managed = check_managed_mcp_registration()
+        now = self.clock()
+        with self._connect() as db:
+            challenge = db.execute(
+                """SELECT * FROM challenges
+                WHERE state IN ('awaiting_phrase', 'ready') AND expires_at > ?
+                ORDER BY created_at DESC LIMIT 1""",
+                (now,),
+            ).fetchone()
+        return {
+            "enabled": bool(record and record.enabled),
+            "health": health,
+            "baselineSafe": baseline.safe,
+            "baselineReasons": list(baseline.reasons),
+            "managedControlsReady": managed.ready,
+            "managedControlReasons": list(managed.reasons),
+            "challenge": self._public_challenge(challenge) if challenge else None,
+        }
+
+    def set_configuration(self, record: KeychainRecord, *, event_type: str) -> None:
+        self.keychain.write(record)
+        with self._connect() as db:
+            db.execute(
+                "INSERT OR REPLACE INTO metadata(key, value) VALUES('configured', '1')"
+            )
+        self.audit.append(event_type, {"enabled": record.enabled}, record=record)
+
+    def require_enabled(self) -> KeychainRecord:
+        health, record = self.health()
+        if health != "ready" or record is None or not record.enabled:
+            raise LockdownDeniedError(f"Voice lockdown is not safely available ({health}).")
+        baseline = check_safe_baseline()
+        if not baseline.safe:
+            self.audit.append("baseline_unsafe", {"reasons": list(baseline.reasons)}, record=record)
+            raise LockdownDeniedError("Configured coding backend baseline is unsafe.")
+        return record
+
+    def create_challenge(self, scope: ApprovalScope, *, action_summary: str) -> dict[str, Any]:
+        record = self.require_enabled()
+        now = self.clock()
+        participant_hash = self._participant_hash(scope)
+        with self._lock, self._connect() as db:
+            cooldown = db.execute(
+                "SELECT until_at FROM cooldowns WHERE participant_hash = ?",
+                (participant_hash,),
+            ).fetchone()
+            if cooldown and float(cooldown["until_at"]) > now:
+                raise LockdownDeniedError("Safe-phrase verification is temporarily rate limited.")
+            db.execute("BEGIN IMMEDIATE")
+            db.execute(
+                "UPDATE challenges SET state = 'revoked' WHERE state IN ('awaiting_phrase', 'ready')"
+            )
+            challenge_id = f"vlc_{uuid.uuid4().hex}"
+            scope_json = json.dumps(asdict(scope), separators=(",", ":"), sort_keys=True)
+            summary = action_summary[:240]
+            expires_at = now + CHALLENGE_TTL_SECONDS
+            challenge_mac = self._challenge_mac(
+                challenge_id,
+                scope_json,
+                summary,
+                expires_at,
+                record,
+            )
+            db.execute(
+                """INSERT INTO challenges(
+                    id, scope_json, action_summary, challenge_mac, created_at, expires_at,
+                    attempts_remaining, state
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 'awaiting_phrase')""",
+                (
+                    challenge_id,
+                    scope_json,
+                    summary,
+                    challenge_mac,
+                    now,
+                    expires_at,
+                    MAX_ATTEMPTS,
+                ),
+            )
+            db.commit()
+        self.audit.append("challenge_created", self._audit_scope(scope), record=record)
+        return self.challenge(challenge_id)
+
+    def challenge(self, challenge_id: str) -> dict[str, Any]:
+        with self._connect() as db:
+            row = db.execute("SELECT * FROM challenges WHERE id = ?", (challenge_id,)).fetchone()
+        if row is None:
+            raise LockdownDeniedError("Voice-lockdown challenge was not found.")
+        return self._public_challenge(row)
+
+    def is_armed(self, *, room_sid: str, participant_identity: str) -> bool:
+        """Return whether transcript events for this exact caller must be suppressed."""
+        health, record = self.health()
+        if health != "ready" or record is None or not record.enabled:
+            return False
+        now = self.clock()
+        with self._connect() as db:
+            rows = db.execute(
+                "SELECT * FROM challenges WHERE state = 'awaiting_phrase' AND expires_at > ?",
+                (now,),
+            ).fetchall()
+        return any(
+            self._challenge_valid(row, record)
+            and (scope := ApprovalScope(**json.loads(row["scope_json"]))).room_sid == room_sid
+            and scope.participant_identity == participant_identity
+            for row in rows
+        )
+
+    def verify_final_utterance(
+        self,
+        transcript: str,
+        *,
+        room_sid: str,
+        participant_identity: str,
+    ) -> str:
+        """Consume one whole final utterance and return a non-secret outcome."""
+        record = self.require_enabled()
+        now = self.clock()
+        with self._lock, self._connect() as db:
+            db.execute("BEGIN IMMEDIATE")
+            rows = db.execute(
+                """SELECT * FROM challenges
+                WHERE state = 'awaiting_phrase' AND expires_at > ?
+                ORDER BY created_at DESC""",
+                (now,),
+            ).fetchall()
+            row = next(
+                (
+                    item
+                    for item in rows
+                    if self._challenge_valid(item, record)
+                    and self._scope_from_row(item).room_sid == room_sid
+                    and self._scope_from_row(item).participant_identity == participant_identity
+                ),
+                None,
+            )
+            if row is None:
+                db.rollback()
+                return "not_armed"
+            scope = self._scope_from_row(row)
+            if verify_phrase(transcript, salt_b64=record.salt, verifier_b64=record.verifier):
+                capability_id = secrets.token_urlsafe(32)
+                capability_expires_at = now + CAPABILITY_TTL_SECONDS
+                capability_mac = self._capability_mac(
+                    capability_id,
+                    row["scope_json"],
+                    capability_expires_at,
+                    record,
+                )
+                db.execute(
+                    """UPDATE challenges SET state = 'ready', capability_id = ?, capability_mac = ?,
+                    capability_expires_at = ? WHERE id = ? AND state = 'awaiting_phrase'""",
+                    (capability_id, capability_mac, capability_expires_at, row["id"]),
+                )
+                db.commit()
+                self.audit.append("capability_issued", self._audit_scope(scope), record=record)
+                return "authorized"
+            attempts = int(row["attempts_remaining"]) - 1
+            new_state = "rate_limited" if attempts <= 0 else "awaiting_phrase"
+            db.execute(
+                "UPDATE challenges SET attempts_remaining = ?, state = ? WHERE id = ?",
+                (max(0, attempts), new_state, row["id"]),
+            )
+            if attempts <= 0:
+                db.execute(
+                    "INSERT OR REPLACE INTO cooldowns(participant_hash, until_at) VALUES(?, ?)",
+                    (self._participant_hash(scope), now + COOLDOWN_SECONDS),
+                )
+            db.commit()
+        self.audit.append(
+            "phrase_mismatch" if attempts > 0 else "rate_limited",
+            {**self._audit_scope(scope), "attemptsRemaining": max(0, attempts)},
+            record=record,
+        )
+        return "mismatch" if attempts > 0 else "rate_limited"
+
+    def consume_capability(self, scope: ApprovalScope) -> bool:
+        """Atomically consume the only ready capability matching exact scope."""
+        try:
+            record = self.require_enabled()
+        except LockdownDeniedError:
+            return False
+        now = self.clock()
+        scope_json = json.dumps(asdict(scope), separators=(",", ":"), sort_keys=True)
+        with self._lock, self._connect() as db:
+            db.execute("BEGIN IMMEDIATE")
+            row = db.execute(
+                """SELECT id FROM challenges WHERE scope_json = ? AND state = 'ready'
+                AND capability_expires_at > ? ORDER BY created_at DESC LIMIT 1""",
+                (scope_json, now),
+            ).fetchone()
+            if row is None:
+                db.rollback()
+                self.audit.append("authorization_denied", self._audit_scope(scope), record=record)
+                return False
+            full_row = db.execute("SELECT * FROM challenges WHERE id = ?", (row["id"],)).fetchone()
+            if full_row is None or not self._capability_valid(full_row, record):
+                db.rollback()
+                self.audit.append("authorization_denied", self._audit_scope(scope), record=record)
+                return False
+            updated = db.execute(
+                """UPDATE challenges SET state = 'consumed', consumed_at = ?
+                WHERE id = ? AND state = 'ready' AND capability_expires_at > ?""",
+                (now, row["id"], now),
+            ).rowcount
+            db.commit()
+        if updated == 1:
+            self.audit.append("capability_consumed", self._audit_scope(scope), record=record)
+            return True
+        return False
+
+    def consume_authorization(self, request: ApprovalAuthorizationRequest) -> bool:
+        """Consume a product-bound lease for one generic backend request."""
+        try:
+            record = self.require_enabled()
+        except LockdownDeniedError:
+            return False
+        now = self.clock()
+        with self._lock, self._connect() as db:
+            db.execute("BEGIN IMMEDIATE")
+            rows = db.execute(
+                """SELECT * FROM challenges WHERE state = 'ready'
+                AND capability_expires_at > ? ORDER BY created_at DESC""",
+                (now,),
+            ).fetchall()
+            row = next(
+                (
+                    item
+                    for item in rows
+                    if self._generic_scope_matches(self._scope_from_row(item), request)
+                ),
+                None,
+            )
+            if row is None:
+                db.rollback()
+                return False
+            if not self._capability_valid(row, record):
+                db.rollback()
+                return False
+            changed = db.execute(
+                """UPDATE challenges SET state = 'consumed', consumed_at = ?
+                WHERE id = ? AND state = 'ready' AND capability_expires_at > ?""",
+                (now, row["id"], now),
+            ).rowcount
+            db.commit()
+        if changed == 1:
+            self.audit.append("capability_consumed", self._audit_scope(self._scope_from_row(row)), record=record)
+            return True
+        return False
+
+    def cancel_challenge(self, challenge_id: str) -> bool:
+        record = self.require_enabled()
+        with self._connect() as db:
+            changed = db.execute(
+                "UPDATE challenges SET state = 'revoked' WHERE id = ? AND state IN ('awaiting_phrase', 'ready')",
+                (challenge_id,),
+            ).rowcount
+        if changed:
+            self.audit.append("challenge_revoked", {"challengeHash": self._hash_id(challenge_id)}, record=record)
+        return changed == 1
+
+    def revoke_all(self, *, reason: str) -> None:
+        health, record = self.health()
+        with self._connect() as db:
+            db.execute("UPDATE challenges SET state = 'revoked' WHERE state IN ('awaiting_phrase', 'ready')")
+        if record is not None:
+            self.audit.append("capabilities_revoked", {"reason": reason[:80], "health": health}, record=record)
+
+    def recent_audit(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        return self.audit.recent(limit=limit)
+
+    @staticmethod
+    def _scope_from_row(row: sqlite3.Row) -> ApprovalScope:
+        return ApprovalScope(**json.loads(row["scope_json"]))
+
+    @staticmethod
+    def _public_challenge(row: sqlite3.Row) -> dict[str, Any]:
+        scope = VoiceLockdownBroker._scope_from_row(row)
+        return {
+            "id": row["id"],
+            "state": row["state"],
+            "expiresAt": row["expires_at"],
+            "capabilityExpiresAt": row["capability_expires_at"],
+            "attemptsRemaining": row["attempts_remaining"],
+            "backend": scope.backend,
+            "requestId": scope.request_id,
+            "threadId": scope.thread_id,
+            "turnId": scope.turn_id,
+            "toolName": scope.tool_name,
+            "actionSummary": row["action_summary"],
+        }
+
+    @staticmethod
+    def _hash_id(value: str) -> str:
+        return hashlib.sha256(value.encode()).hexdigest()[:16]
+
+    def _participant_hash(self, scope: ApprovalScope) -> str:
+        return self._hash_id(f"{scope.room_sid}\0{scope.participant_identity}")
+
+    def _audit_scope(self, scope: ApprovalScope) -> dict[str, Any]:
+        return {
+            "backend": scope.backend,
+            "requestHash": self._hash_id(scope.request_id),
+            "threadHash": self._hash_id(scope.thread_id),
+            "turnHash": self._hash_id(scope.turn_id),
+            "toolCallHash": self._hash_id(scope.tool_call_id),
+            "toolName": scope.tool_name,
+            "actionDigest": scope.action_digest,
+            "roomHash": self._hash_id(scope.room_sid),
+            "participantHash": self._hash_id(scope.participant_identity),
+        }
+
+    @staticmethod
+    def _generic_scope_matches(scope: ApprovalScope, request: ApprovalAuthorizationRequest) -> bool:
+        return (
+            scope.backend == request.backend
+            and scope.request_id == request.request_id
+            and scope.thread_id == (request.thread_id or "")
+            and scope.turn_id == (request.turn_id or "")
+            and scope.tool_call_id == (request.tool_call_id or "")
+            and scope.tool_name == request.action_type
+            and scope.action_digest == request.action_digest
+        )
+
+    @staticmethod
+    def _capability_mac(
+        capability_id: str,
+        scope_json: str,
+        expires_at: float,
+        record: KeychainRecord,
+    ) -> str:
+        payload = f"{capability_id}|{scope_json}|{expires_at:.6f}".encode()
+        return hmac.new(base64.b64decode(record.audit_key), payload, hashlib.sha256).hexdigest()
+
+    @staticmethod
+    def _challenge_mac(
+        challenge_id: str,
+        scope_json: str,
+        action_summary: str,
+        expires_at: float,
+        record: KeychainRecord,
+    ) -> str:
+        payload = f"{challenge_id}|{scope_json}|{action_summary}|{expires_at:.6f}".encode()
+        return hmac.new(base64.b64decode(record.audit_key), payload, hashlib.sha256).hexdigest()
+
+    @classmethod
+    def _challenge_valid(cls, row: sqlite3.Row, record: KeychainRecord) -> bool:
+        challenge_mac = row["challenge_mac"]
+        if not isinstance(challenge_mac, str):
+            return False
+        expected = cls._challenge_mac(
+            row["id"],
+            row["scope_json"],
+            row["action_summary"],
+            float(row["expires_at"]),
+            record,
+        )
+        return hmac.compare_digest(expected, challenge_mac)
+
+    @classmethod
+    def _capability_valid(cls, row: sqlite3.Row, record: KeychainRecord) -> bool:
+        capability_id = row["capability_id"]
+        capability_mac = row["capability_mac"]
+        expires_at = row["capability_expires_at"]
+        if not isinstance(capability_id, str) or not isinstance(capability_mac, str) or expires_at is None:
+            return False
+        expected = cls._capability_mac(
+            capability_id,
+            row["scope_json"],
+            float(expires_at),
+            record,
+        )
+        return hmac.compare_digest(expected, capability_mac)
+
+
+_BROKER: VoiceLockdownBroker | None = None
+
+
+def get_voice_lockdown_broker() -> VoiceLockdownBroker:
+    global _BROKER
+    if _BROKER is None:
+        _BROKER = VoiceLockdownBroker()
+    return _BROKER
+
+
+def require_safe_baseline() -> BaselineCheck:
+    check = check_safe_baseline()
+    if not check.safe:
+        raise LockdownDeniedError("; ".join(check.reasons))
+    return check

--- a/openbase_coder_cli/voice_lockdown/execution_controls.py
+++ b/openbase_coder_cli/voice_lockdown/execution_controls.py
@@ -1,0 +1,68 @@
+"""Openbase adapter for generic Super Agents execution-control protocols."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from super_agents.execution_control import (
+    ApprovalAuthorizationRequest,
+    AuthorizationDecision,
+    ExecutionRequest,
+)
+
+from .broker import get_voice_lockdown_broker
+from .policy import check_safe_baseline
+
+
+def _unsafe_requested_policy(policy: dict[str, Any]) -> str | None:
+    approval = str(policy.get("approvalPolicy") or "").strip().lower()
+    if approval == "never":
+        return "approvalPolicy=never is prohibited"
+    sandbox = policy.get("sandboxPolicy") or policy.get("sandbox")
+    sandbox_type = sandbox.get("type") if isinstance(sandbox, dict) else sandbox
+    if str(sandbox_type or "").strip().lower().replace("-", "") == "dangerfullaccess":
+        return "danger-full-access is prohibited"
+    permission_mode = str(policy.get("permissionMode") or "").strip().lower()
+    if permission_mode in {"bypasspermissions", "dontask"}:
+        return f"Claude permission mode {permission_mode} is prohibited"
+    return None
+
+
+class LockdownExecutionPolicyGuard:
+    async def validate(self, request: ExecutionRequest) -> AuthorizationDecision:
+        broker = get_voice_lockdown_broker()
+        health, record = broker.health()
+        if health in {"unconfigured", "disabled"}:
+            return AuthorizationDecision(allowed=True)
+        if health != "ready" or record is None:
+            return AuthorizationDecision(allowed=False, reason="Lockdown state is unavailable or corrupt.")
+        baseline = check_safe_baseline()
+        if not baseline.safe:
+            return AuthorizationDecision(allowed=False, reason="Configured backend baseline is unsafe.")
+        if reason := _unsafe_requested_policy(request.requested_policy):
+            return AuthorizationDecision(allowed=False, reason=reason)
+        return AuthorizationDecision(allowed=True)
+
+
+class LockdownApprovalAuthorizer:
+    async def authorize(self, request: ApprovalAuthorizationRequest) -> AuthorizationDecision:
+        broker = get_voice_lockdown_broker()
+        health, record = broker.health()
+        if health in {"unconfigured", "disabled"}:
+            return AuthorizationDecision(allowed=True)
+        if health != "ready" or record is None:
+            return AuthorizationDecision(allowed=False, reason="Lockdown state is unavailable or corrupt.")
+        if broker.consume_authorization(request):
+            return AuthorizationDecision(allowed=True)
+        return AuthorizationDecision(
+            allowed=False,
+            reason="No unexpired one-use authorization matches this exact approval.",
+        )
+
+
+def managed_execution_controls() -> dict[str, Any]:
+    return {
+        "execution_policy_guard": LockdownExecutionPolicyGuard(),
+        "approval_authorizer": LockdownApprovalAuthorizer(),
+        "require_controls": True,
+    }

--- a/openbase_coder_cli/voice_lockdown/keychain.py
+++ b/openbase_coder_cli/voice_lockdown/keychain.py
@@ -1,0 +1,124 @@
+"""Authoritative macOS Keychain storage for voice-lockdown configuration."""
+
+from __future__ import annotations
+
+import json
+import platform
+import subprocess
+from dataclasses import dataclass
+from typing import Any
+
+KEYCHAIN_SERVICE = "cloud.openbase.coder.voice-lockdown.v1"
+KEYCHAIN_ACCOUNT = "configuration"
+
+
+class KeychainUnavailableError(RuntimeError):
+    pass
+
+
+class KeychainCorruptError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class KeychainRecord:
+    enabled: bool
+    salt: str
+    verifier: str
+    audit_key: str
+    version: int = 1
+
+    @classmethod
+    def from_json(cls, raw: str) -> "KeychainRecord":
+        try:
+            value = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise KeychainCorruptError("Voice-lockdown Keychain data is invalid JSON.") from exc
+        if not isinstance(value, dict):
+            raise KeychainCorruptError("Voice-lockdown Keychain data is not an object.")
+        try:
+            record = cls(
+                enabled=value["enabled"],
+                salt=value["salt"],
+                verifier=value["verifier"],
+                audit_key=value["auditKey"],
+                version=value["version"],
+            )
+        except (KeyError, TypeError) as exc:
+            raise KeychainCorruptError("Voice-lockdown Keychain data is incomplete.") from exc
+        if (
+            record.version != 1
+            or not isinstance(record.enabled, bool)
+            or not all(isinstance(item, str) and item for item in (record.salt, record.verifier, record.audit_key))
+        ):
+            raise KeychainCorruptError("Voice-lockdown Keychain data failed validation.")
+        return record
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "version": self.version,
+                "enabled": self.enabled,
+                "salt": self.salt,
+                "verifier": self.verifier,
+                "auditKey": self.audit_key,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+
+class MacOSKeychain:
+    """Small injectable wrapper; there is deliberately no non-Keychain fallback."""
+
+    def __init__(self, *, runner: Any = subprocess.run) -> None:
+        self._runner = runner
+
+    def _require_macos(self) -> None:
+        if platform.system() != "Darwin":
+            raise KeychainUnavailableError("Voice lockdown requires macOS Keychain.")
+
+    def read(self) -> KeychainRecord | None:
+        self._require_macos()
+        result = self._runner(
+            [
+                "/usr/bin/security",
+                "find-generic-password",
+                "-s",
+                KEYCHAIN_SERVICE,
+                "-a",
+                KEYCHAIN_ACCOUNT,
+                "-w",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 44:
+            return None
+        if result.returncode != 0:
+            raise KeychainUnavailableError("Unable to read voice-lockdown state from macOS Keychain.")
+        return KeychainRecord.from_json(result.stdout.strip())
+
+    def write(self, record: KeychainRecord) -> None:
+        self._require_macos()
+        # With no value following -w, security reads the secret from stdin;
+        # this keeps it out of argv and process listings.
+        result = self._runner(
+            [
+                "/usr/bin/security",
+                "add-generic-password",
+                "-U",
+                "-s",
+                KEYCHAIN_SERVICE,
+                "-a",
+                KEYCHAIN_ACCOUNT,
+                "-w",
+            ],
+            input=record.to_json(),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise KeychainUnavailableError("Unable to write voice-lockdown state to macOS Keychain.")

--- a/openbase_coder_cli/voice_lockdown/policy.py
+++ b/openbase_coder_cli/voice_lockdown/policy.py
@@ -1,0 +1,112 @@
+"""Safe-baseline preflight; lockdown never repairs an unsafe baseline."""
+
+from __future__ import annotations
+
+import json
+import os
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+from openbase_coder_cli.codex_session_defaults import codex_permission_defaults
+from openbase_coder_cli.paths import (
+    CODEX_HOME_DIR,
+    DEFAULT_ENV_FILE_PATH,
+    OPENBASE_CLAUDE_JSON_PATH,
+)
+
+UNSAFE_CODEX_APPROVAL_POLICIES = {"never"}
+UNSAFE_CODEX_SANDBOXES = {"danger-full-access", "dangerfullaccess"}
+UNSAFE_CLAUDE_PERMISSION_MODES = {"bypasspermissions", "dontask"}
+
+
+@dataclass(frozen=True, slots=True)
+class BaselineCheck:
+    safe: bool
+    reasons: tuple[str, ...]
+    configured_backends: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedControlsCheck:
+    ready: bool
+    reasons: tuple[str, ...]
+
+
+def check_safe_baseline(env: dict[str, str] | None = None) -> BaselineCheck:
+    values = (
+        {
+            **{key: value for key, value in dotenv_values(DEFAULT_ENV_FILE_PATH).items() if value is not None},
+            **os.environ,
+        }
+        if env is None
+        else env
+    )
+    raw_backends = values.get("OPENBASE_CODING_BACKEND", "codex")
+    configured = tuple(
+        dict.fromkeys(
+            part.strip().lower().replace("-", "_").replace(" ", "_")
+            for part in raw_backends.split(",")
+            if part.strip()
+        )
+    ) or ("codex",)
+    reasons: list[str] = []
+    permissions = codex_permission_defaults(values)
+    for backend in configured:
+        if backend in {"codex", "openbase_cloud_codex"}:
+            approval = permissions["approvalPolicy"].strip().lower()
+            sandbox = permissions["sandbox"].strip().lower().replace("_", "-")
+            if approval in UNSAFE_CODEX_APPROVAL_POLICIES:
+                reasons.append(f"{backend} approval policy is unsafe: {approval}")
+            if sandbox.replace("-", "") in UNSAFE_CODEX_SANDBOXES or sandbox in UNSAFE_CODEX_SANDBOXES:
+                reasons.append(f"{backend} sandbox is unsafe: {sandbox}")
+            if approval not in {"untrusted", "on-failure", "on-request"}:
+                reasons.append(f"{backend} approval policy is unknown: {approval}")
+            if sandbox not in {"read-only", "workspace-write"}:
+                reasons.append(f"{backend} sandbox is unknown: {sandbox}")
+        elif backend in {"claude_code", "openbase_cloud"}:
+            mode = values.get("SUPER_AGENTS_CLAUDE_PERMISSION_MODE", "bypassPermissions")
+            normalized = mode.strip().lower()
+            if normalized in UNSAFE_CLAUDE_PERMISSION_MODES:
+                reasons.append(f"{backend} permission mode is unsafe: {mode}")
+            elif normalized not in {"default", "acceptedits"}:
+                reasons.append(f"{backend} permission mode is unknown: {mode}")
+        else:
+            reasons.append(f"configured backend is unknown: {backend}")
+    return BaselineCheck(not reasons, tuple(reasons), configured)
+
+
+def check_managed_mcp_registration(
+    *,
+    codex_config: Path = CODEX_HOME_DIR / "config.toml",
+    claude_config: Path = OPENBASE_CLAUDE_JSON_PATH,
+) -> ManagedControlsCheck:
+    """Ensure managed MCP registrations use the required Openbase wrapper."""
+    reasons: list[str] = []
+    if codex_config.exists():
+        try:
+            payload = tomllib.loads(codex_config.read_text(encoding="utf-8"))
+            entry = payload.get("mcp_servers", {}).get("super-agents", {})
+        except (OSError, tomllib.TOMLDecodeError, AttributeError):
+            entry = {}
+        if entry and not _is_managed_entry(entry):
+            reasons.append("Codex Super Agents MCP registration bypasses Openbase execution controls")
+    if claude_config.exists():
+        try:
+            payload = json.loads(claude_config.read_text(encoding="utf-8"))
+            entry = payload.get("mcpServers", {}).get("super-agents", {})
+        except (OSError, json.JSONDecodeError, AttributeError):
+            entry = {}
+        if entry and not _is_managed_entry(entry):
+            reasons.append("Claude Super Agents MCP registration bypasses Openbase execution controls")
+    return ManagedControlsCheck(not reasons, tuple(reasons))
+
+
+def _is_managed_entry(entry: object) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    command = Path(str(entry.get("command") or "")).name
+    args = entry.get("args") or []
+    return command == "openbase-coder" and isinstance(args, list) and "super-agents-mcp" in args

--- a/openbase_coder_cli/voice_lockdown/verifier.py
+++ b/openbase_coder_cli/voice_lockdown/verifier.py
@@ -1,0 +1,53 @@
+"""Phrase normalization and memory-hard verification."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import re
+import unicodedata
+
+MIN_PHRASE_WORDS = 6
+MIN_PHRASE_CHARS = 24
+
+
+def normalize_phrase(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    normalized = normalized.translate(str.maketrans({"’": "'", "‘": "'", "`": "'"}))
+    normalized = " ".join(normalized.split())
+    return re.sub(r"[.?!]+$", "", normalized).strip()
+
+
+def validate_new_phrase(value: str) -> str:
+    normalized = normalize_phrase(value)
+    if len(normalized) < MIN_PHRASE_CHARS or len(normalized.split()) < MIN_PHRASE_WORDS:
+        raise ValueError(
+            f"Safe phrase must contain at least {MIN_PHRASE_WORDS} words and {MIN_PHRASE_CHARS} characters."
+        )
+    return normalized
+
+
+def derive_verifier(normalized_phrase: str, salt: bytes) -> str:
+    # scrypt is available through Python's audited OpenSSL binding and keeps
+    # offline guesses expensive without introducing a plaintext fallback.
+    derived = hashlib.scrypt(
+        normalized_phrase.encode("utf-8"),
+        salt=salt,
+        n=2**15,
+        r=8,
+        p=1,
+        maxmem=64 * 1024 * 1024,
+        dklen=32,
+    )
+    return base64.b64encode(derived).decode("ascii")
+
+
+def verify_phrase(value: str, *, salt_b64: str, verifier_b64: str) -> bool:
+    try:
+        salt = base64.b64decode(salt_b64, validate=True)
+        expected = base64.b64decode(verifier_b64, validate=True)
+        actual = base64.b64decode(derive_verifier(normalize_phrase(value), salt), validate=True)
+    except (ValueError, TypeError):
+        return False
+    return hmac.compare_digest(actual, expected)

--- a/tests/test_voice_lockdown.py
+++ b/tests/test_voice_lockdown.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import base64
+import json
+import sqlite3
+import threading
+from dataclasses import replace
+
+import pytest
+from super_agents.execution_control import ApprovalAuthorizationRequest
+
+from openbase_coder_cli.voice_lockdown.broker import (
+    ApprovalScope,
+    VoiceLockdownBroker,
+    canonical_action_digest,
+)
+from openbase_coder_cli.voice_lockdown.keychain import KeychainRecord
+from openbase_coder_cli.voice_lockdown.policy import (
+    check_managed_mcp_registration,
+    check_safe_baseline,
+)
+from openbase_coder_cli.voice_lockdown.verifier import (
+    derive_verifier,
+    normalize_phrase,
+    validate_new_phrase,
+)
+
+PHRASE = "amber river cedar lantern velvet harbor"
+
+
+class FakeKeychain:
+    def __init__(self, record=None):
+        self.record = record
+
+    def read(self):
+        return self.record
+
+    def write(self, record):
+        self.record = record
+
+
+def _record(*, enabled=True):
+    salt = b"0123456789abcdef"
+    return KeychainRecord(
+        enabled=enabled,
+        salt=base64.b64encode(salt).decode(),
+        verifier=derive_verifier(normalize_phrase(PHRASE), salt),
+        audit_key=base64.b64encode(b"a" * 32).decode(),
+    )
+
+
+def _scope():
+    action = {"method": "item/commandExecution/requestApproval", "tool": "shell", "input": {"command": "true"}}
+    return ApprovalScope(
+        backend="codex",
+        request_id="request-1",
+        thread_id="thread-1",
+        turn_id="turn-1",
+        tool_call_id="tool-call-1",
+        tool_name="shell",
+        action_digest=canonical_action_digest(action),
+        room_sid="room-1",
+        participant_identity="owner-1",
+    )
+
+
+def _request(scope):
+    return ApprovalAuthorizationRequest(
+        backend=scope.backend,
+        request_id=scope.request_id,
+        action_type=scope.tool_name,
+        action_digest=scope.action_digest,
+        thread_id=scope.thread_id,
+        turn_id=scope.turn_id,
+        tool_call_id=scope.tool_call_id,
+    )
+
+
+def _broker(db_path, *, record=None, clock=None):
+    keychain = FakeKeychain()
+    broker = VoiceLockdownBroker(
+        db_path=db_path,
+        keychain=keychain,
+        **({"clock": clock} if clock is not None else {}),
+    )
+    broker.set_configuration(record or _record(), event_type="configured")
+    return broker
+
+
+@pytest.fixture(autouse=True)
+def safe_codex_baseline(monkeypatch):
+    monkeypatch.setenv("OPENBASE_CODING_BACKEND", "codex")
+    monkeypatch.setenv("LIVEKIT_CODEX_APPROVAL_POLICY", "on-request")
+    monkeypatch.setenv("LIVEKIT_CODEX_SANDBOX", "read-only")
+
+
+def test_phrase_matching_is_exact_whole_utterance():
+    assert normalize_phrase("  Amber   River Cedar Lantern Velvet Harbor?! ") == PHRASE
+    assert normalize_phrase(f"please {PHRASE}") != PHRASE
+    assert normalize_phrase(f"{PHRASE} now") != PHRASE
+    assert validate_new_phrase(PHRASE) == PHRASE
+
+
+def test_default_baseline_is_rejected():
+    check = check_safe_baseline(
+        {
+            "OPENBASE_CODING_BACKEND": "codex",
+            "LIVEKIT_CODEX_APPROVAL_POLICY": "never",
+            "LIVEKIT_CODEX_SANDBOX": "danger-full-access",
+        }
+    )
+    assert not check.safe
+    assert any("approval policy is unsafe" in reason for reason in check.reasons)
+    assert any("sandbox is unsafe" in reason for reason in check.reasons)
+
+
+def test_enable_preflight_rejects_unguarded_mcp_registration(tmp_path):
+    codex = tmp_path / "config.toml"
+    claude = tmp_path / ".claude.json"
+    codex.write_text('[mcp_servers.super-agents]\ncommand = "super-agents-mcp"\n')
+    claude.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "super-agents": {
+                        "command": "/managed/bin/openbase-coder",
+                        "args": ["super-agents-mcp"],
+                    }
+                }
+            }
+        )
+    )
+    check = check_managed_mcp_registration(codex_config=codex, claude_config=claude)
+    assert not check.ready
+    codex.write_text(
+        '[mcp_servers.super-agents]\ncommand = "/managed/bin/openbase-coder"\nargs = ["super-agents-mcp"]\n'
+    )
+    assert check_managed_mcp_registration(
+        codex_config=codex, claude_config=claude
+    ).ready
+
+
+def test_one_phrase_issues_one_exact_30_second_capability(tmp_path):
+    now = [100.0]
+    broker = _broker(tmp_path / "lockdown.sqlite3", clock=lambda: now[0])
+    scope = _scope()
+    broker.create_challenge(scope, action_summary="Run a command")
+    assert broker.verify_final_utterance(
+        f"please {PHRASE}", room_sid=scope.room_sid, participant_identity=scope.participant_identity
+    ) == "mismatch"
+    assert broker.verify_final_utterance(
+        PHRASE, room_sid=scope.room_sid, participant_identity=scope.participant_identity
+    ) == "authorized"
+    assert broker.consume_authorization(_request(scope))
+    assert not broker.consume_authorization(_request(scope))
+
+    broker.create_challenge(scope, action_summary="Run a command")
+    assert broker.verify_final_utterance(
+        PHRASE, room_sid=scope.room_sid, participant_identity=scope.participant_identity
+    ) == "authorized"
+    now[0] += 31
+    assert not broker.consume_authorization(_request(scope))
+
+
+def test_capability_rejects_every_scope_substitution(tmp_path):
+    broker = _broker(tmp_path / "lockdown.sqlite3")
+    scope = _scope()
+    broker.create_challenge(scope, action_summary="Run a command")
+    assert broker.verify_final_utterance(
+        PHRASE, room_sid=scope.room_sid, participant_identity=scope.participant_identity
+    ) == "authorized"
+    for field, value in (
+        ("backend", "claude_code"),
+        ("request_id", "other"),
+        ("thread_id", "other"),
+        ("turn_id", "other"),
+        ("tool_call_id", "other"),
+        ("tool_name", "other"),
+        ("action_digest", "0" * 64),
+    ):
+        assert not broker.consume_authorization(_request(replace(scope, **{field: value})))
+    assert broker.consume_authorization(_request(scope))
+
+
+def test_atomic_consumption_has_one_winner_and_persists_no_phrase(tmp_path):
+    db_path = tmp_path / "lockdown.sqlite3"
+    broker = _broker(db_path)
+    scope = _scope()
+    broker.create_challenge(scope, action_summary="Run a command")
+    broker.verify_final_utterance(
+        PHRASE, room_sid=scope.room_sid, participant_identity=scope.participant_identity
+    )
+    results: list[bool] = []
+
+    def consume():
+        results.append(broker.consume_authorization(_request(scope)))
+
+    threads = [threading.Thread(target=consume) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert results.count(True) == 1
+    assert PHRASE.encode() not in db_path.read_bytes()
+    assert PHRASE not in json.dumps(broker.recent_audit())
+
+
+def test_missing_keychain_after_configuration_is_indeterminate(tmp_path):
+    keychain = FakeKeychain()
+    broker = VoiceLockdownBroker(db_path=tmp_path / "lockdown.sqlite3", keychain=keychain)
+    broker.set_configuration(_record(enabled=False), event_type="configured")
+    keychain.record = None
+    assert broker.status()["health"] == "indeterminate"
+
+
+def test_tampered_audit_chain_fails_closed(tmp_path):
+    broker = _broker(tmp_path / "lockdown.sqlite3")
+    with sqlite3.connect(broker.db_path) as db:
+        db.execute("UPDATE audit_events SET detail_json = '{}' WHERE sequence = 1")
+    assert broker.status()["health"] == "indeterminate"
+
+
+def test_tampered_capability_state_cannot_authorize(tmp_path):
+    broker = _broker(tmp_path / "lockdown.sqlite3")
+    scope = _scope()
+    broker.create_challenge(scope, action_summary="Run a command")
+    broker.verify_final_utterance(
+        PHRASE, room_sid=scope.room_sid, participant_identity=scope.participant_identity
+    )
+    with sqlite3.connect(broker.db_path) as db:
+        db.execute("UPDATE challenges SET capability_mac = ? WHERE state = 'ready'", ("0" * 64,))
+    assert not broker.consume_authorization(_request(scope))
+
+
+def test_tampered_challenge_scope_cannot_verify_phrase(tmp_path):
+    broker = _broker(tmp_path / "lockdown.sqlite3")
+    scope = _scope()
+    broker.create_challenge(scope, action_summary="Run a command")
+    with sqlite3.connect(broker.db_path) as db:
+        db.execute(
+            "UPDATE challenges SET scope_json = replace(scope_json, 'request-1', 'request-2')"
+        )
+    assert (
+        broker.verify_final_utterance(
+            PHRASE,
+            room_sid=scope.room_sid,
+            participant_identity=scope.participant_identity,
+        )
+        == "not_armed"
+    )

--- a/tests/test_voice_lockdown_api.py
+++ b/tests/test_voice_lockdown_api.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("OPENBASE_CODER_CLI_SECRET_KEY", "test-secret")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "openbase_coder_cli.config.settings")
+
+import django  # noqa: E402
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+django.setup()
+
+from openbase_coder_cli.openbase_coder_cli_app import lockdown  # noqa: E402
+
+
+class FakeManager:
+    async def list_approval_requests(self):
+        return [
+            {
+                "id": "request-1",
+                "method": "item/commandExecution/requestApproval",
+                "params": {
+                    "backend": "codex",
+                    "threadId": "thread-1",
+                    "turnId": "turn-1",
+                    "toolCallId": "tool-1",
+                    "toolName": "shell",
+                    "command": "true",
+                    "description": "Run a command",
+                },
+            }
+        ]
+
+
+class FakeBroker:
+    def __init__(self):
+        self.scope = None
+
+    def status(self):
+        return {"enabled": True, "health": "ready", "challenge": None}
+
+    def create_challenge(self, scope, *, action_summary):
+        self.scope = scope
+        return {
+            "id": "challenge-1",
+            "state": "awaiting_phrase",
+            "requestId": scope.request_id,
+            "actionSummary": action_summary,
+        }
+
+
+def _authenticated(request):
+    force_authenticate(request, user=SimpleNamespace(is_authenticated=True))
+    return request
+
+
+def test_status_requires_authentication():
+    response = lockdown.lockdown_status(APIRequestFactory().get("/api/lockdown/"))
+    assert response.status_code in {401, 403}
+
+
+def test_challenge_api_uses_pending_request_and_returns_no_secret(monkeypatch):
+    broker = FakeBroker()
+    monkeypatch.setattr(lockdown, "get_session_manager", lambda: FakeManager())
+    monkeypatch.setattr(lockdown, "get_voice_lockdown_broker", lambda: broker)
+    request = _authenticated(
+        APIRequestFactory().post(
+            "/api/lockdown/challenges/",
+            {
+                "requestId": "request-1",
+                "roomSid": "room-1",
+                "participantIdentity": "owner-1",
+            },
+            format="json",
+        )
+    )
+    response = lockdown.lockdown_challenges(request)
+    assert response.status_code == 201
+    assert broker.scope.request_id == "request-1"
+    assert broker.scope.room_sid == "room-1"
+    serialized = str(response.data).lower()
+    for forbidden in ("'phrase':", "verifier", "capability", "salt", "pepper"):
+        assert forbidden not in serialized

--- a/tests/test_voice_lockdown_controls.py
+++ b/tests/test_voice_lockdown_controls.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from super_agents.execution_control import (
+    ApprovalAuthorizationRequest,
+    ExecutionRequest,
+)
+
+from openbase_coder_cli.voice_lockdown.execution_controls import (
+    LockdownApprovalAuthorizer,
+    LockdownExecutionPolicyGuard,
+)
+
+
+class FakeBroker:
+    def __init__(self, health="ready", consumed=True):
+        self._health = health
+        self._consumed = consumed
+
+    def health(self):
+        return self._health, object() if self._health in {"ready", "disabled"} else None
+
+    def consume_authorization(self, request):
+        return self._consumed
+
+
+async def test_enabled_guard_rejects_yolo_and_danger(monkeypatch):
+    broker = FakeBroker()
+    monkeypatch.setattr(
+        "openbase_coder_cli.voice_lockdown.execution_controls.get_voice_lockdown_broker",
+        lambda: broker,
+    )
+    monkeypatch.setenv("OPENBASE_CODING_BACKEND", "codex")
+    monkeypatch.setenv("LIVEKIT_CODEX_APPROVAL_POLICY", "on-request")
+    monkeypatch.setenv("LIVEKIT_CODEX_SANDBOX", "read-only")
+    guard = LockdownExecutionPolicyGuard()
+    request = ExecutionRequest("codex", "start_turn", {"approvalPolicy": "never"}, "digest")
+    assert not (await guard.validate(request)).allowed
+    request = ExecutionRequest("codex", "start_turn", {"sandbox": "danger-full-access"}, "digest")
+    assert not (await guard.validate(request)).allowed
+
+
+async def test_indeterminate_state_fails_closed(monkeypatch):
+    monkeypatch.setattr(
+        "openbase_coder_cli.voice_lockdown.execution_controls.get_voice_lockdown_broker",
+        lambda: FakeBroker(health="indeterminate"),
+    )
+    guard = LockdownExecutionPolicyGuard()
+    assert not (await guard.validate(ExecutionRequest("codex", "start_turn", {}, "digest"))).allowed
+    authorizer = LockdownApprovalAuthorizer()
+    request = ApprovalAuthorizationRequest("codex", "r", "shell", "digest")
+    assert not (await authorizer.authorize(request)).allowed
+
+
+async def test_decline_bypasses_authorizer_in_super_agents():
+    # Decline/cancel bypass is exercised at the generic client boundary in
+    # Super Agents; this assertion documents that the product authorizer only
+    # handles accept requests and cannot turn a denial into an approval.
+    authorizer = LockdownApprovalAuthorizer()
+    assert not hasattr(authorizer, "decline")

--- a/tests/test_voice_lockdown_keychain.py
+++ b/tests/test_voice_lockdown_keychain.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from openbase_coder_cli.voice_lockdown.keychain import (
+    KEYCHAIN_SERVICE,
+    KeychainRecord,
+    KeychainUnavailableError,
+    MacOSKeychain,
+)
+
+
+def _record():
+    return KeychainRecord(False, "salt", "verifier", "audit-key")
+
+
+def test_keychain_write_keeps_secret_json_out_of_argv(monkeypatch):
+    calls = []
+
+    def runner(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    MacOSKeychain(runner=runner).write(_record())
+    argv, kwargs = calls[0]
+    assert KEYCHAIN_SERVICE in argv
+    assert _record().to_json() not in " ".join(argv)
+    assert kwargs["input"] == _record().to_json()
+
+
+def test_non_macos_has_no_file_or_environment_fallback(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    with pytest.raises(KeychainUnavailableError):
+        MacOSKeychain().read()

--- a/tests/test_voice_lockdown_stt.py
+++ b/tests/test_voice_lockdown_stt.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from livekit.agents import stt as livekit_stt
+
+from openbase_coder_cli.livekit_agent.lockdown_stt import VoiceLockdownStream
+
+
+def _event(kind, text=""):
+    alternatives = []
+    if text:
+        alternatives = [livekit_stt.SpeechData(language="en", text=text, confidence=1.0)]
+    return livekit_stt.SpeechEvent(type=kind, alternatives=alternatives)
+
+
+class FakeStream:
+    def __init__(self, events):
+        self.events = iter(events)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self.events)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class FakeBroker:
+    def __init__(self):
+        self.armed = True
+        self.candidates = []
+
+    def is_armed(self, **scope):
+        return self.armed
+
+    def verify_final_utterance(self, transcript, **scope):
+        self.candidates.append((transcript, scope))
+        self.armed = False
+        return "authorized"
+
+
+async def test_armed_partial_and_final_are_consumed_before_outer_wrappers():
+    phrase = "amber river cedar lantern velvet harbor"
+    broker = FakeBroker()
+    outcomes = []
+    stream = VoiceLockdownStream(
+        FakeStream(
+            [
+                _event(livekit_stt.SpeechEventType.INTERIM_TRANSCRIPT, "amber river"),
+                _event(livekit_stt.SpeechEventType.FINAL_TRANSCRIPT, phrase),
+                _event(livekit_stt.SpeechEventType.FINAL_TRANSCRIPT, phrase),
+                _event(livekit_stt.SpeechEventType.START_OF_SPEECH),
+            ]
+        ),
+        broker=broker,
+        room_sid="room-1",
+        participant_identity="owner-1",
+        on_outcome=outcomes.append,
+    )
+    forwarded = await stream.__anext__()
+    assert forwarded.type == livekit_stt.SpeechEventType.START_OF_SPEECH
+    assert broker.candidates == [
+        (phrase, {"room_sid": "room-1", "participant_identity": "owner-1"})
+    ]
+    assert outcomes == ["authorized"]
+
+
+async def test_unarmed_transcript_passes_through_unchanged():
+    broker = FakeBroker()
+    broker.armed = False
+    event = _event(livekit_stt.SpeechEventType.FINAL_TRANSCRIPT, "normal request")
+    stream = VoiceLockdownStream(
+        FakeStream([event]),
+        broker=broker,
+        room_sid="room-1",
+        participant_identity="owner-1",
+        on_outcome=lambda _outcome: None,
+    )
+    assert await stream.__anext__() is event


### PR DESCRIPTION
## Summary

- adds macOS Keychain-only phrase configuration with no plaintext or file fallback
- gates exactly one already-pending approval with a 30-second, atomically consumed capability
- binds authorization to backend, request, thread, turn, tool call, action digest, room, and participant
- suppresses armed interim/final speech before logging, history, steering, and model input
- adds authenticated non-secret status/challenge APIs, HMAC-chained audit events, safe-baseline preflight, and managed Super Agents control injection
- refuses enablement for yolo, danger-full-access, Claude bypass, or unguarded managed MCP registration

## Validation

- Ruff passed
- 1,266 CLI tests passed; one persistent-state watchdog test was isolated and passed separately
- 19 focused lockdown tests passed
- staged gitleaks passed
- Semgrep found only the intentional owner-only 0700 directory-permission false positive

## Safety

Review-only draft. Do not merge until the dependent generic Super Agents controls and a physical-device LiveKit test are reviewed.