### PR TITLE
Onboarding: allow anonymous local access to status and cloud-state endpoints

### DIFF
--- a/openbase_coder_cli/openbase_coder_cli_app/onboarding.py
+++ b/openbase_coder_cli/openbase_coder_cli_app/onboarding.py
@@ -3,19 +3,28 @@
 from __future__ import annotations
 
 from rest_framework import status
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 from openbase_coder_cli.services.onboarding import onboarding_status_payload
 
+# AllowAny: the desktop onboarding shell polls these endpoints anonymously —
+# they are how the UI learns the user just signed in, so they cannot sit
+# behind the local JWT they help bootstrap. Localhost callers can already
+# mint a full JWT via the AllowAny /api/auth/refresh-jwt/ endpoint, so this
+# exposes nothing a local process could not already read.
+
 
 @api_view(["GET"])
+@permission_classes([AllowAny])
 def onboarding_status(request):
     """Report local onboarding state (CLI configured, Tailscale, auth)."""
     return Response(onboarding_status_payload(), status=status.HTTP_200_OK)
 
 
 @api_view(["GET"])
+@permission_classes([AllowAny])
 def onboarding_cloud_state(request):
     """Live cloud device-registry state for the signed-in user.
 

--- a/tests/test_onboarding_status_api.py
+++ b/tests/test_onboarding_status_api.py
@@ -48,6 +48,26 @@ def test_onboarding_status_returns_payload(monkeypatch) -> None:
     assert response.data == _fake_status_payload()
 
 
+def test_onboarding_status_allows_anonymous_requests(monkeypatch) -> None:
+    # Regression: the desktop onboarding shell polls this endpoint without a
+    # local JWT (it is how the UI learns the user just signed in). The default
+    # IsAuthenticated permission returned 401, which the shell swallowed, so
+    # onboarding stuck at "Sign in to Openbase" after every successful login.
+    from openbase_coder_cli.openbase_coder_cli_app import (
+        onboarding as onboarding_views,
+    )
+
+    monkeypatch.setattr(
+        onboarding_views, "onboarding_status_payload", _fake_status_payload
+    )
+
+    request = APIRequestFactory().get("/api/onboarding/status/")
+    response = views.onboarding_status(request)
+
+    assert response.status_code == 200
+    assert response.data == _fake_status_payload()
+
+
 def test_onboarding_status_payload_composes_checks(monkeypatch, tmp_path) -> None:
     env_file = tmp_path / ".env"
     env_file.write_text("KEY=value\n", encoding="utf-8")


### PR DESCRIPTION
## Problem

Onboarding in the packaged desktop app sticks at **"Sign in to Openbase"** even after `openbase-coder login` succeeds. The sign-in state panel keeps showing "Not signed in" and "Continue to phone link" stays disabled, no matter how many times login is re-run or "Recheck status" is clicked.

## Root cause

The desktop onboarding shell polls `GET /api/onboarding/status/` (and `/api/onboarding/cloud-state/` on the pairing step) **anonymously** — these endpoints are how the UI learns the user just signed in, so they run before any local JWT exists and cannot sit behind the token they help bootstrap.

DRF's global default is `IsAuthenticated` (`config/settings.py`), and unlike the other pre-auth local endpoints (`auth.py`, `diagnostics.py`, `plugins_tools.py`) these two views never got an `AllowAny` exemption. Every poll returned 401, the shell's `if (!response.ok) return;` swallowed it silently, and the onboarding facts never populated.

Dev-workspace setups never hit this path (they use the CLI + authenticated console), which is why only packaged installs appeared broken.

## Fix

- Add `@permission_classes([AllowAny])` to `onboarding_status` and `onboarding_cloud_state`, with a comment documenting why.
- Security-wise this exposes nothing new: any localhost caller can already mint a full JWT via the existing `AllowAny` `/api/auth/refresh-jwt/` endpoint, so localhost is already the trust boundary.

## Tests

- Added a regression test asserting the status endpoint accepts anonymous requests. The existing test used `force_authenticate`, which masked exactly this failure.
- `pytest tests/test_onboarding_status_api.py` — 15 passed.
- Verified end-to-end on a live install: hot-patching the running 0.36.0 package with this change and restarting `django-cli` immediately unstuck onboarding, advancing from the sign-in step to the phone-link step.
