### PR TITLE
thread-sync: discover newest Codex state DB instead of pinning state_5

### DIFF
--- a/openbase_coder_cli/thread_sync/thread_exchange.py
+++ b/openbase_coder_cli/thread_sync/thread_exchange.py
@@ -24,7 +24,6 @@ from openbase_coder_cli.paths import (
 from .thread_import import (
     DEFAULT_SYNC_MAX_AGE_DAYS,
     SESSION_INDEX_NAME,
-    STATE_DB_NAME,
     SYNC_LEDGER_NAME,
     ThreadTransferError,
     _active_super_agent_thread_ids,
@@ -40,6 +39,7 @@ from .thread_import import (
     _thread_fingerprint,
     _thread_rows,
     _thread_safe_for_sync,
+    state_db_path,
 )
 from .thread_sync_common import (
     DeviceIdentity,
@@ -157,7 +157,7 @@ def export_thread_snapshots(
     active_thread_ids: set[str] | None = None,
     source_user_home: Path | None = None,
 ) -> list[ThreadSnapshotResult]:
-    state_db = codex_home / STATE_DB_NAME
+    state_db = state_db_path(codex_home)
     if not state_db.exists():
         raise ThreadTransferError(f"Codex state database not found: {state_db}")
 
@@ -283,7 +283,7 @@ def import_thread_snapshots(
     ledger_path: Path = DEFAULT_LEDGER_PATH,
     target_user_home: Path | None = None,
 ) -> list[ThreadSnapshotResult]:
-    state_db = codex_home / STATE_DB_NAME
+    state_db = state_db_path(codex_home)
     if not state_db.exists():
         raise ThreadTransferError(f"Codex state database not found: {state_db}")
 
@@ -403,7 +403,7 @@ def thread_snapshot_conflicts_payload(
     identity = read_device_identity(device_identity_path)
     ledger = _read_exchange_ledger(ledger_path)
     conflicts: list[dict[str, Any]] = []
-    state_db = codex_home / STATE_DB_NAME
+    state_db = state_db_path(codex_home)
     for thread_id, thread_ledger in ledger.get("threads", {}).items():
         if not isinstance(thread_id, str) or not isinstance(thread_ledger, dict):
             continue
@@ -507,8 +507,8 @@ def thread_home_sync_conflicts_payload(
         logger=logger,
         malformed_event="codex_thread_sync_ledger_malformed",
     )
-    normal_db = normal_home / STATE_DB_NAME
-    voice_db = voice_home / STATE_DB_NAME
+    normal_db = state_db_path(normal_home)
+    voice_db = state_db_path(voice_home)
     conflicts: list[dict[str, Any]] = []
     for thread_id, thread_ledger in ledger.items():
         if not isinstance(thread_id, str) or not isinstance(thread_ledger, dict):
@@ -584,7 +584,7 @@ def resolve_thread_snapshot_conflict(
     if not source_device_id:
         raise ThreadConflictResolutionError("source_device_not_found")
 
-    state_db = codex_home / STATE_DB_NAME
+    state_db = state_db_path(codex_home)
     local_row = _exchange_thread_row(state_db, thread_id)
     local_fingerprint = _fingerprint_id(
         _thread_fingerprint(local_row, codex_home, thread_id)
@@ -894,7 +894,7 @@ def _apply_snapshot_db_state(
         thread_row["cwd"] = translated_cwd
     dynamic_tools = metadata.get("dynamic_tools")
     dynamic_tools = dynamic_tools if isinstance(dynamic_tools, list) else []
-    with closing(_connect(codex_home / STATE_DB_NAME)) as conn:
+    with closing(_connect(state_db_path(codex_home))) as conn:
         _upsert_thread_row(
             conn, thread_id, thread_row, target_rollout, overwrite=overwrite
         )

--- a/openbase_coder_cli/thread_sync/thread_import.py
+++ b/openbase_coder_cli/thread_sync/thread_import.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 import shutil
 import sqlite3
 import subprocess
@@ -32,6 +33,7 @@ from .thread_sync_common import (
 )
 
 STATE_DB_NAME = "state_5.sqlite"
+_STATE_DB_PATTERN = re.compile(r"state_(\d+)\.sqlite")
 SESSION_INDEX_NAME = "session_index.jsonl"
 SYNC_LEDGER_NAME = "codex-thread-sync-ledger.json"
 TERMINAL_EVENT_TYPES = {"task_complete", "turn_aborted"}
@@ -45,6 +47,31 @@ FINGERPRINT_MATCH_KEYS = (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def state_db_path(home: Path) -> Path:
+    """Path of the newest-schema ``state_<N>.sqlite`` in ``home``.
+
+    Codex leaves superseded state databases in place when a schema migration
+    creates the next ``state_<N>`` file, so a pinned filename would keep
+    syncing the frozen pre-migration database after a Codex upgrade.
+    """
+    best_version: int | None = None
+    best_path = home / STATE_DB_NAME
+    for candidate in home.glob("state_*.sqlite"):
+        match = _STATE_DB_PATTERN.fullmatch(candidate.name)
+        if match is None:
+            continue
+        version = int(match.group(1))
+        if best_version is None or version > best_version:
+            best_version = version
+            best_path = candidate
+    return best_path
+
+
+def _state_db_version(path: Path) -> int | None:
+    match = _STATE_DB_PATTERN.fullmatch(path.name)
+    return int(match.group(1)) if match else None
 
 
 @dataclass(frozen=True)
@@ -188,9 +215,9 @@ def list_codex_threads_for_transfer(
     include_transferred: bool = True,
 ) -> list[CodexThreadTransferCandidate]:
     """List Codex threads in one home and mark whether they exist in another."""
-    source_db = source_home / STATE_DB_NAME
+    source_db = state_db_path(source_home)
     index_by_id = _latest_session_index_entries(source_home / SESSION_INDEX_NAME)
-    target_thread_ids = _target_thread_ids(target_home / STATE_DB_NAME)
+    target_thread_ids = _target_thread_ids(state_db_path(target_home))
     rows = _thread_rows(source_db)
 
     threads: list[CodexThreadTransferCandidate] = []
@@ -282,12 +309,17 @@ def sync_codex_threads_once(
     active_thread_ids: set[str] | None = None,
 ) -> list[CodexThreadSyncResult]:
     """Run one conservative bidirectional sync pass between Codex homes."""
-    normal_db = normal_home / STATE_DB_NAME
-    voice_db = voice_home / STATE_DB_NAME
+    normal_db = state_db_path(normal_home)
+    voice_db = state_db_path(voice_home)
     if not normal_db.exists():
         raise ThreadTransferError(f"Normal Codex state database not found: {normal_db}")
     if not voice_db.exists():
         raise ThreadTransferError(f"Voice Codex state database not found: {voice_db}")
+    if _state_db_version(normal_db) != _state_db_version(voice_db):
+        raise ThreadTransferError(
+            "Codex state schema mismatch between homes: "
+            f"{normal_db.name} (normal) vs {voice_db.name} (voice)"
+        )
 
     active_ids = set(active_thread_ids or set()) | _active_super_agent_thread_ids()
     ledger = _read_sync_ledger(ledger_path)
@@ -350,8 +382,8 @@ def transfer_codex_threads(
     if not thread_ids:
         raise ValueError("thread_ids must not be empty")
 
-    source_db = source_home / STATE_DB_NAME
-    target_db = target_home / STATE_DB_NAME
+    source_db = state_db_path(source_home)
+    target_db = state_db_path(target_home)
     if not source_db.exists():
         raise ThreadTransferError(
             f"{source_label} state database not found: {source_db}"

--- a/tests/test_thread_import.py
+++ b/tests/test_thread_import.py
@@ -6,14 +6,18 @@ import sqlite3
 import time
 from pathlib import Path
 
+import pytest
+
 from openbase_coder_cli.thread_sync.thread_import import (
     CodexThreadSyncResult,
+    ThreadTransferError,
     _active_super_agent_thread_ids,
     _log_sync_result,
     export_voice_codex_threads,
     import_normal_codex_threads,
     list_normal_codex_threads,
     list_voice_codex_threads,
+    state_db_path,
     sync_codex_threads_once,
 )
 
@@ -458,7 +462,9 @@ def test_sync_codex_threads_once_logs_conflict_and_continues(
     _append_terminal(normal_conflict, message="normal")
     _append_terminal(voice_conflict, message="voice")
     _append_terminal(ok_rollout, message="ok")
-    caplog.set_level(logging.WARNING, logger="openbase_coder_cli.thread_sync.thread_import")
+    caplog.set_level(
+        logging.WARNING, logger="openbase_coder_cli.thread_sync.thread_import"
+    )
 
     results = sync_codex_threads_once(
         normal_home=normal_home,
@@ -604,7 +610,9 @@ def test_sync_codex_threads_once_skips_threads_older_than_max_age(
 
 
 def test_sync_result_logging_suppresses_routine_results(caplog) -> None:
-    caplog.set_level(logging.INFO, logger="openbase_coder_cli.thread_sync.thread_import")
+    caplog.set_level(
+        logging.INFO, logger="openbase_coder_cli.thread_sync.thread_import"
+    )
 
     _log_sync_result(
         CodexThreadSyncResult("thread-old", "skipped", None, "skipped_old")
@@ -726,3 +734,33 @@ def test_active_super_agent_thread_ids_honors_store_home_env(
     active = _active_super_agent_thread_ids(state_path=tmp_path / "missing-state.json")
 
     assert active == {"0197aaaa-1111-2222-3333-444455556666"}
+
+
+def test_state_db_path_prefers_newest_schema_version(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    _create_state_db(home / "state_5.sqlite")
+    _create_state_db(home / "state_6.sqlite")
+    (home / "state.db").write_text("", encoding="utf-8")
+
+    assert state_db_path(home) == home / "state_6.sqlite"
+
+
+def test_state_db_path_defaults_when_no_versioned_db(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    assert state_db_path(home) == home / "state_5.sqlite"
+
+
+def test_sync_codex_threads_once_raises_on_schema_mismatch(tmp_path: Path) -> None:
+    normal_home = tmp_path / "normal"
+    voice_home = tmp_path / "voice"
+    _create_state_db(normal_home / "state_6.sqlite")
+    _create_state_db(voice_home / "state_5.sqlite")
+
+    with pytest.raises(ThreadTransferError, match="schema mismatch"):
+        sync_codex_threads_once(
+            normal_home=normal_home,
+            voice_home=voice_home,
+            ledger_path=tmp_path / "ledger.json",
+        )


### PR DESCRIPTION
## Problem
`thread_import.py` pins `STATE_DB_NAME = "state_5.sqlite"`, and Codex leaves superseded state DBs behind when a schema migration creates the next `state_<N>` file (live installs still carry a legacy pre-versioned `state.db`). After the next Codex schema bump, home↔home thread sync would keep sweeping the frozen `state_5` databases on both sides and silently miss every new thread — no error, no surfacing.

## Fix
- `state_db_path(home)` resolves the highest-versioned `state_<N>.sqlite` in a home, falling back to the legacy default name when none exists.
- All state-DB lookups in `thread_import.py` and `thread_exchange.py` go through it.
- `sync_codex_threads_once` now raises `ThreadTransferError` when the two homes are on different schema versions (a transient state during staggered migration), so the sweep logs errors loudly instead of syncing across mismatched schemas.

## Testing
- New unit tests: newest-version discovery, legacy fallback, schema-mismatch error.
- `tests/test_thread_import.py tests/test_thread_exchange.py tests/test_codex_sync_cli.py`: 40 passed. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)