### PR TITLE
thread-sync: tolerate undecodable rollout lines instead of stranding threads

### DIFF
--- a/openbase_coder_cli/thread_sync/thread_import.py
+++ b/openbase_coder_cli/thread_sync/thread_import.py
@@ -747,7 +747,9 @@ def _thread_safe_for_sync(
         return ThreadSyncSafety(False, "rollout_not_found")
     if not path_stable(rollout, stability_delay_seconds):
         return ThreadSyncSafety(False, "skipped_unstable")
-    terminal = _rollout_terminal_event(rollout)
+    terminal, has_undecodable_lines = _rollout_terminal_event(rollout)
+    if has_undecodable_lines and _rollout_open_for_write(rollout):
+        return ThreadSyncSafety(False, "skipped_active")
     if terminal is None:
         return ThreadSyncSafety(False, "rollout_malformed")
     if terminal not in TERMINAL_EVENT_TYPES:
@@ -763,31 +765,41 @@ def _target_row_safe_for_overwrite(
     thread_id: str,
 ) -> bool:
     rollout = _source_rollout_path(row, home, thread_id)
-    return (
-        rollout is not None
-        and not _rollout_open_for_write(rollout)
-        and _rollout_terminal_event(rollout) in TERMINAL_EVENT_TYPES
-    )
+    if rollout is None or _rollout_open_for_write(rollout):
+        return False
+    terminal, _ = _rollout_terminal_event(rollout)
+    return terminal in TERMINAL_EVENT_TYPES
 
 
-def _rollout_terminal_event(path: Path) -> str | None:
+def _rollout_terminal_event(path: Path) -> tuple[str | None, bool]:
+    """Last parseable event type, plus whether any line failed to decode.
+
+    Undecodable lines are skipped rather than poisoning the rollout: a crash
+    mid-append leaves a truncated tail forever, and treating that as malformed
+    would permanently strand the thread from sync. Callers must still treat
+    undecodable content in a file that is open for write as an in-progress
+    append, not history.
+    """
     last_event_type: str | None = None
+    has_undecodable_lines = False
     for line in path.read_text(encoding="utf-8").splitlines():
         if not line.strip():
             continue
         try:
             event = json.loads(line)
         except json.JSONDecodeError:
-            return None
+            has_undecodable_lines = True
+            continue
         if not isinstance(event, dict):
-            return None
+            has_undecodable_lines = True
+            continue
         event_type = _string(event.get("type"))
         payload = event.get("payload")
         if event_type == "event_msg" and isinstance(payload, dict):
             last_event_type = _string(payload.get("type"))
         elif event_type:
             last_event_type = event_type
-    return last_event_type
+    return last_event_type, has_undecodable_lines
 
 
 def _rollout_open_for_write(path: Path) -> bool:

--- a/tests/test_thread_import.py
+++ b/tests/test_thread_import.py
@@ -458,7 +458,9 @@ def test_sync_codex_threads_once_logs_conflict_and_continues(
     _append_terminal(normal_conflict, message="normal")
     _append_terminal(voice_conflict, message="voice")
     _append_terminal(ok_rollout, message="ok")
-    caplog.set_level(logging.WARNING, logger="openbase_coder_cli.thread_sync.thread_import")
+    caplog.set_level(
+        logging.WARNING, logger="openbase_coder_cli.thread_sync.thread_import"
+    )
 
     results = sync_codex_threads_once(
         normal_home=normal_home,
@@ -604,7 +606,9 @@ def test_sync_codex_threads_once_skips_threads_older_than_max_age(
 
 
 def test_sync_result_logging_suppresses_routine_results(caplog) -> None:
-    caplog.set_level(logging.INFO, logger="openbase_coder_cli.thread_sync.thread_import")
+    caplog.set_level(
+        logging.INFO, logger="openbase_coder_cli.thread_sync.thread_import"
+    )
 
     _log_sync_result(
         CodexThreadSyncResult("thread-old", "skipped", None, "skipped_old")
@@ -726,3 +730,101 @@ def test_active_super_agent_thread_ids_honors_store_home_env(
     active = _active_super_agent_thread_ids(state_path=tmp_path / "missing-state.json")
 
     assert active == {"0197aaaa-1111-2222-3333-444455556666"}
+
+
+def _append_truncated_line(rollout_path: Path) -> None:
+    with rollout_path.open("a", encoding="utf-8") as handle:
+        handle.write('{"timestamp": "2026-05-21T12:00:01.000Z", "type": "eve')
+
+
+def test_sync_codex_threads_once_transfers_thread_with_truncated_tail(
+    tmp_path: Path,
+) -> None:
+    normal_home = tmp_path / "normal"
+    voice_home = tmp_path / "voice"
+    ledger = tmp_path / "ledger.json"
+    _create_state_db(normal_home / "state_5.sqlite")
+    _create_state_db(voice_home / "state_5.sqlite")
+    source_rollout = _insert_thread(
+        normal_home,
+        "thread-1",
+        title="Thread title",
+        updated_at=20,
+    )
+    _append_terminal(source_rollout)
+    _append_truncated_line(source_rollout)
+
+    results = sync_codex_threads_once(
+        normal_home=normal_home,
+        voice_home=voice_home,
+        ledger_path=ledger,
+        stability_delay_seconds=0,
+        max_age_days=None,
+    )
+
+    assert [(result.thread_id, result.status) for result in results] == [
+        ("thread-1", "transferred")
+    ]
+    target_rollout = voice_home / source_rollout.relative_to(normal_home)
+    assert target_rollout.exists()
+
+
+def test_sync_codex_threads_once_skips_truncated_rollout_open_for_write(
+    tmp_path: Path,
+) -> None:
+    normal_home = tmp_path / "normal"
+    voice_home = tmp_path / "voice"
+    ledger = tmp_path / "ledger.json"
+    _create_state_db(normal_home / "state_5.sqlite")
+    _create_state_db(voice_home / "state_5.sqlite")
+    source_rollout = _insert_thread(
+        normal_home,
+        "thread-1",
+        title="Thread title",
+        updated_at=20,
+    )
+    _append_terminal(source_rollout)
+    with source_rollout.open("a", encoding="utf-8") as handle:
+        handle.write('{"timestamp": "2026-05-21T12:00:01.000Z", "type": "eve')
+        handle.flush()
+
+        results = sync_codex_threads_once(
+            normal_home=normal_home,
+            voice_home=voice_home,
+            ledger_path=ledger,
+            stability_delay_seconds=0,
+            max_age_days=None,
+        )
+
+    assert [(result.thread_id, result.status, result.reason) for result in results] == [
+        ("thread-1", "skipped", "skipped_active")
+    ]
+
+
+def test_sync_codex_threads_once_marks_rollout_without_events_malformed(
+    tmp_path: Path,
+) -> None:
+    normal_home = tmp_path / "normal"
+    voice_home = tmp_path / "voice"
+    ledger = tmp_path / "ledger.json"
+    _create_state_db(normal_home / "state_5.sqlite")
+    _create_state_db(voice_home / "state_5.sqlite")
+    source_rollout = _insert_thread(
+        normal_home,
+        "thread-1",
+        title="Thread title",
+        updated_at=20,
+    )
+    source_rollout.write_text("not json at all\n", encoding="utf-8")
+
+    results = sync_codex_threads_once(
+        normal_home=normal_home,
+        voice_home=voice_home,
+        ledger_path=ledger,
+        stability_delay_seconds=0,
+        max_age_days=None,
+    )
+
+    assert [(result.thread_id, result.status, result.reason) for result in results] == [
+        ("thread-1", "skipped", "rollout_malformed")
+    ]


### PR DESCRIPTION
## Problem
`_rollout_terminal_event` returned `None` if any line in a rollout failed JSON decode, so a single truncated line (e.g. Codex crashing mid-append) marked the thread `rollout_malformed` on every sweep, permanently excluding it from home↔home sync. A live install currently has such a thread skipped every 60 seconds with no path to convergence.

## Fix
- `_rollout_terminal_event` now skips undecodable/non-dict lines and reports whether any were seen, reserving `rollout_malformed` for rollouts with no parseable events at all.
- `_thread_safe_for_sync` treats undecodable content in a file that is open for write as an in-progress append (`skipped_active`), preserving the old protection against copying mid-write rollouts.
- `_target_row_safe_for_overwrite` keeps requiring a closed file plus a terminal event.

## Testing
- New tests: truncated tail after a terminal event syncs; truncated tail on an open file is skipped as active; rollout with no parseable events stays `rollout_malformed`.
- `tests/test_thread_import.py tests/test_thread_exchange.py` plus sync CLI suites: 74 passed. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)