### PR TITLE
thread-sync: stop re-validating unchanged invalid device snapshots

### DIFF
--- a/openbase_coder_cli/thread_sync/thread_sync_common.py
+++ b/openbase_coder_cli/thread_sync/thread_sync_common.py
@@ -24,6 +24,11 @@ DEFAULT_SUPER_AGENTS_STORE_HOME = (
 )
 SUPER_AGENTS_STORE_HOME_ENV = "SUPER_AGENTS_CLAUDE_CODE_HOME"
 
+# Device-ledger section remembering exchange snapshots whose metadata was
+# rejected, keyed by "<parent>/<snapshot dir>" with the metadata file's stat
+# signature, so unchanged invalid snapshots are not re-parsed every sweep.
+INVALID_SNAPSHOT_CACHE_KEY = "invalid_snapshots"
+
 
 def merged_sync_conflicts_payload(
     home_conflicts: dict[str, Any],
@@ -611,7 +616,10 @@ def run_snapshot_import(
     # Oldest-first so that within one pass a stale divergent snapshot is
     # processed before the newer one that proves convergence and clears the
     # conflict, never the other way around.
-    return [
+    snapshot_dirs = sorted(
+        device_snapshot_dirs(exchange_dir), key=_snapshot_exported_at
+    )
+    results = [
         _import_one_snapshot(
             snapshot_dir,
             device_id=device_id,
@@ -619,10 +627,42 @@ def run_snapshot_import(
             source=source,
             result_factory=result_factory,
         )
-        for snapshot_dir in sorted(
-            device_snapshot_dirs(exchange_dir), key=_snapshot_exported_at
-        )
+        for snapshot_dir in snapshot_dirs
     ]
+    _prune_invalid_snapshot_cache(ledger, snapshot_dirs)
+    return results
+
+
+def _invalid_snapshot_cache(ledger: dict[str, Any]) -> dict[str, Any]:
+    cache = ledger.setdefault(INVALID_SNAPSHOT_CACHE_KEY, {})
+    if not isinstance(cache, dict):
+        cache = {}
+        ledger[INVALID_SNAPSHOT_CACHE_KEY] = cache
+    return cache
+
+
+def _invalid_snapshot_cache_key(snapshot_dir: Path) -> str:
+    return f"{snapshot_dir.parent.name}/{snapshot_dir.name}"
+
+
+def _metadata_signature(path: Path) -> list[int] | None:
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return [stat.st_size, stat.st_mtime_ns]
+
+
+def _prune_invalid_snapshot_cache(
+    ledger: dict[str, Any], snapshot_dirs: list[Path]
+) -> None:
+    cache = ledger.get(INVALID_SNAPSHOT_CACHE_KEY)
+    if not isinstance(cache, dict):
+        return
+    live_keys = {_invalid_snapshot_cache_key(path) for path in snapshot_dirs}
+    for key in list(cache):
+        if key not in live_keys:
+            del cache[key]
 
 
 def _snapshot_exported_at(snapshot_dir: Path) -> float:
@@ -642,12 +682,35 @@ def _import_one_snapshot(
     source: SnapshotImportSource,
     result_factory: Callable[..., Any],
 ) -> Any:
+    # Permanently-invalid snapshots (e.g. legacy exports missing metadata
+    # fields) would otherwise be re-read and re-rejected on every sweep;
+    # remember the rejection keyed by the metadata file's stat signature so
+    # they cost one stat per sweep but still re-validate if the file changes.
+    invalid_cache = _invalid_snapshot_cache(ledger)
+    cache_key = _invalid_snapshot_cache_key(snapshot_dir)
+    metadata_path = snapshot_dir / "metadata.json"
+    signature = _metadata_signature(metadata_path)
+    cached = invalid_cache.get(cache_key)
+    if (
+        isinstance(cached, dict)
+        and signature is not None
+        and cached.get("signature") == signature
+    ):
+        return result_factory(
+            snapshot_dir.parent.name,
+            "skipped",
+            str(cached.get("reason")),
+            str(snapshot_dir),
+        )
     try:
-        metadata = source.read_metadata(snapshot_dir / "metadata.json")
+        metadata = source.read_metadata(metadata_path)
     except source.metadata_error as exc:
+        if signature is not None:
+            invalid_cache[cache_key] = {"reason": str(exc), "signature": signature}
         return result_factory(
             snapshot_dir.parent.name, "skipped", str(exc), str(snapshot_dir)
         )
+    invalid_cache.pop(cache_key, None)
 
     entity_id = metadata[source.entity_id_key]
     source_device_id = metadata["source_device_id"]

--- a/tests/test_thread_exchange.py
+++ b/tests/test_thread_exchange.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import sqlite3
 from pathlib import Path
 
@@ -975,3 +976,104 @@ def test_import_auto_clears_conflict_after_content_converges(tmp_path: Path) -> 
         ledger_path=target_ledger,
     )
     assert status["conflict_count"] == 0
+
+
+def _exported_snapshot_metadata_path(exchange_dir: Path) -> Path:
+    snapshot_dirs = sorted((exchange_dir / "devices").glob("*/snapshots/*/*"))
+    assert len(snapshot_dirs) == 1
+    return snapshot_dirs[0] / "metadata.json"
+
+
+def test_import_caches_invalid_snapshot_and_revalidates_on_change(
+    tmp_path: Path,
+) -> None:
+    source_home = tmp_path / "source"
+    target_home = tmp_path / "target"
+    exchange_dir = tmp_path / "exchange"
+    ledger_path = tmp_path / "target-ledger.json"
+    _create_state_db(source_home / "state_5.sqlite")
+    _create_state_db(target_home / "state_5.sqlite")
+    _insert_thread(source_home, "thread-1", title="Thread title", updated_at=20)
+    export_thread_snapshots(
+        codex_home=source_home,
+        exchange_dir=exchange_dir,
+        device_identity_path=tmp_path / "source-device.json",
+        ledger_path=tmp_path / "source-ledger.json",
+        stability_delay_seconds=0,
+        max_age_days=None,
+    )
+    metadata_path = _exported_snapshot_metadata_path(exchange_dir)
+    valid_metadata = metadata_path.read_text(encoding="utf-8")
+    metadata_path.write_text("not json", encoding="utf-8")
+
+    def run_import() -> list:
+        return import_thread_snapshots(
+            codex_home=target_home,
+            exchange_dir=exchange_dir,
+            device_identity_path=tmp_path / "target-device.json",
+            ledger_path=ledger_path,
+        )
+
+    first = run_import()
+    assert [result.status for result in first] == ["skipped"]
+    ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+    assert len(ledger["invalid_snapshots"]) == 1
+
+    # An unchanged invalid snapshot must not be re-read: make the metadata
+    # unreadable so any parse attempt would raise.
+    metadata_path.chmod(0o000)
+    try:
+        second = run_import()
+    finally:
+        metadata_path.chmod(0o600)
+    assert [(result.status, result.reason) for result in second] == [
+        (first[0].status, first[0].reason)
+    ]
+
+    metadata_path.write_text(valid_metadata, encoding="utf-8")
+    third = run_import()
+    assert [result.status for result in third] == ["imported"]
+    ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+    assert ledger["invalid_snapshots"] == {}
+
+
+def test_import_prunes_cache_entries_for_removed_snapshots(tmp_path: Path) -> None:
+    source_home = tmp_path / "source"
+    target_home = tmp_path / "target"
+    exchange_dir = tmp_path / "exchange"
+    ledger_path = tmp_path / "target-ledger.json"
+    _create_state_db(source_home / "state_5.sqlite")
+    _create_state_db(target_home / "state_5.sqlite")
+    _insert_thread(source_home, "thread-1", title="Thread title", updated_at=20)
+    export_thread_snapshots(
+        codex_home=source_home,
+        exchange_dir=exchange_dir,
+        device_identity_path=tmp_path / "source-device.json",
+        ledger_path=tmp_path / "source-ledger.json",
+        stability_delay_seconds=0,
+        max_age_days=None,
+    )
+    metadata_path = _exported_snapshot_metadata_path(exchange_dir)
+    metadata_path.write_text("not json", encoding="utf-8")
+
+    import_thread_snapshots(
+        codex_home=target_home,
+        exchange_dir=exchange_dir,
+        device_identity_path=tmp_path / "target-device.json",
+        ledger_path=ledger_path,
+    )
+    assert (
+        len(json.loads(ledger_path.read_text(encoding="utf-8"))["invalid_snapshots"])
+        == 1
+    )
+
+    shutil.rmtree(metadata_path.parent)
+    import_thread_snapshots(
+        codex_home=target_home,
+        exchange_dir=exchange_dir,
+        device_identity_path=tmp_path / "target-device.json",
+        ledger_path=ledger_path,
+    )
+    assert (
+        json.loads(ledger_path.read_text(encoding="utf-8"))["invalid_snapshots"] == {}
+    )


### PR DESCRIPTION
## Problem
Device-exchange snapshots rejected for metadata errors (e.g. legacy exports missing `session_id`) are re-read, re-parsed, and re-rejected on every 60-second sweep, forever — a live install currently re-skips 569 such snapshots per Claude device sweep. The rejections happen before any ledger recording, so nothing remembers them.

## Fix
- `_import_one_snapshot` records metadata rejections in a new `invalid_snapshots` device-ledger section keyed by `<parent>/<snapshot-dir>`, with the metadata file's stat signature (size + mtime_ns).
- Unchanged invalid snapshots now cost one `stat()` per sweep and return the same skip reason (sweep summaries unchanged); if the metadata file changes, it is re-validated automatically, and a successful parse clears the cache entry.
- `run_snapshot_import` prunes cache entries for snapshot dirs that no longer exist. Both ledger readers/writers round-trip unknown top-level sections, so the cache persists with no schema change.

## Testing
- New tests prove the cache path is used (second sweep succeeds with the metadata file made unreadable), that a restored metadata file is re-validated and imported, and that removed snapshots are pruned.
- `tests/test_thread_exchange.py tests/test_thread_sync_common.py tests/test_claude_thread_sync.py` plus sync CLI suites: 73 passed. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)