### PR TITLE
docs: refresh CLI command docs

### DIFF
--- a/docs/commands/plugins.md
+++ b/docs/commands/plugins.md
@@ -22,6 +22,7 @@ openbase-coder plugins COMMAND [ARGS]
 | `remove PLUGIN_ID` | Uninstall a plugin |
 | `update [PLUGIN_ID] [--ref REF]` | Update one plugin or all plugins |
 | `bootstrappers` | List all discovered bootstrapper names |
+| `rebuild-site` | Rebuild the stable plugin site directory from the plugin registry |
 
 ## Source Types
 
@@ -46,14 +47,11 @@ openbase-coder plugins add https://github.com/org/openbase-plugin --ref main
 
 ## Where Plugin Packages Install
 
-In development installs, plugin Python packages install into the workspace CLI
-venv, which persists on its own.
-
-In standalone installs, the versioned runtime package is replaced wholesale on
-upgrade, so plugin packages install into the stable plugin site directory
-`~/.openbase/plugins/site` instead. Every Openbase Coder process adds that
-directory to `sys.path` at startup, so desktop package upgrades do not lose
-installed plugins.
+Plugin Python packages install into the stable plugin site directory
+`~/.openbase/plugins/site` in both development and standalone installs. Every
+Openbase Coder process adds that directory to `sys.path` at startup, so
+desktop package upgrades and development `uv sync` runs do not lose installed
+plugins.
 
 ## What Happens on Add/Update/Remove
 

--- a/docs/commands/sync.md
+++ b/docs/commands/sync.md
@@ -14,11 +14,15 @@ openbase-coder sync COMMAND [ARGS]
 
 | Subcommand | Description |
 |---|---|
+| `install-engine` | Pre-fetch the pinned Syncthing engine without enabling sync |
 | `enable` | Create the sync identity, render config/ignores, install and start the `code-sync` service, and advertise sync capabilities to Openbase Cloud |
 | `disable` | Stop and remove the `code-sync` service (local data and version history are kept) |
 | `status` | Show enablement, eligibility, folders, peers, and conflict counts |
 | `add PATH` | Add a directory under `$HOME` to sync (stored as a home-relative path) |
 | `remove PATH` | Stop syncing a directory (files stay on disk) |
+| `ignores list [--folder RELPATH]` | Show custom Syncthing ignore rules for a synced folder |
+| `ignores add PATTERN [--folder RELPATH]` | Add a custom Syncthing ignore pattern to a synced folder |
+| `ignores remove PATTERN [--folder RELPATH]` | Remove a custom Syncthing ignore pattern from a synced folder |
 | `conflicts` | List unresolved repo and file conflicts |
 | `resolve ID --keep-local\|--use-remote` | Resolve one conflict (`--use-remote` safety-stashes the working tree first) |
 | `reconcile [--loop]` | Run one git-state reconcile tick, or loop forever |


### PR DESCRIPTION
## Summary

Documentation freshness audit for `cli/docs/` product docs. I checked five command docs against the current CLI/source: `commands/plugins.md`, `commands/sync.md`, `commands/service.md`, `commands/backend.md`, and `commands/server.md`.

## Stale Claims Fixed

- `docs/commands/plugins.md` omitted the registered `plugins rebuild-site` subcommand. Code evidence: `openbase_coder_cli/cli/plugins.py` registers `@plugins.command("rebuild-site")`.
- `docs/commands/plugins.md` said development installs put plugin Python packages in the workspace CLI venv. Code evidence: `openbase_coder_cli/plugins/site.py` makes `use_plugin_site()` always return `True` and documents dev/standalone sharing `~/.openbase/plugins/site`.
- `docs/commands/sync.md` omitted the registered `sync install-engine` subcommand. Code evidence: `openbase_coder_cli/cli/sync.py` registers `@sync.command("install-engine")`.
- `docs/commands/sync.md` omitted the registered `sync ignores list/add/remove` subcommands. Code evidence: `openbase_coder_cli/cli/sync.py` registers `@sync.group()` plus `@ignores.command("list")`, `@ignores.command("add")`, and `@ignores.command("remove")`.

## Verified Current

- `docs/commands/service.md` matched `openbase_coder_cli/cli/service.py` and `openbase_coder_cli/services/published_services.py` for publish/list/unpublish, dynamic/private tailnet ports, loopback probing, opt-in persistence, and Openbase Direct rejection.
- `docs/commands/backend.md` matched `openbase_coder_cli/cli/backend.py`, `openbase_coder_cli/backend_config.py`, and service runner setup for selectable backends and `OPENBASE_CODING_BACKEND`.
- `docs/commands/server.md` matched `openbase_coder_cli/cli/server.py` for options, startup sequence, direct Uvicorn at one worker, and Gunicorn for multiple workers.

## Verification

- `git diff --check origin/develop...HEAD`

Note: the `doc-freshness` label does not exist in this repo, so none was applied.