### PR TITLE
Fix netmesh dev-setup on public clones; persist staging cloud override

### DIFF
--- a/openbase_coder_cli/cli/setup/env.py
+++ b/openbase_coder_cli/cli/setup/env.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import secrets
 from pathlib import Path
 
@@ -78,7 +79,12 @@ def _ensure_env_file(
                 if key not in current_values
             }
         )
-        release_backend_url = default_web_backend_url()
+        # An explicit env override at setup time (e.g. pointing a dev install
+        # at staging) must be persisted, or services silently target the
+        # channel default afterwards.
+        release_backend_url = (
+            os.environ.get(WEB_BACKEND_ENV_KEY) or default_web_backend_url()
+        )
         if (
             release_backend_url != PRODUCTION_WEB_BACKEND_URL
             and WEB_BACKEND_ENV_KEY not in current_values
@@ -174,7 +180,11 @@ def _ensure_env_file(
         "OPENBASE_CODER_CLI_OAUTH_CLIENT_ID=openbase-coder-cli",
     ]
 
-    release_backend_url = default_web_backend_url()
+    # Persist an explicit env override (e.g. a staging-targeted dev install)
+    # alongside the channel default so bare CLI commands and services agree.
+    release_backend_url = (
+        os.environ.get(WEB_BACKEND_ENV_KEY) or default_web_backend_url()
+    )
     if release_backend_url != PRODUCTION_WEB_BACKEND_URL:
         lines.append(f"{WEB_BACKEND_ENV_KEY}={release_backend_url}")
 

--- a/openbase_coder_cli/cli/setup/env.py
+++ b/openbase_coder_cli/cli/setup/env.py
@@ -53,7 +53,7 @@ from openbase_coder_cli.services.tailscale_provider import (
 
 TAILNET_PROVIDER_ENV_KEY = "OPENBASE_CODER_CLI_TAILSCALE_PROVIDER"
 ALLOWED_HOSTS_ENV_KEY = "OPENBASE_CODER_CLI_ALLOWED_HOSTS"
-NETMESH_ALLOWED_SUFFIX = ".net.obs.so"
+NETMESH_ALLOWED_SUFFIXES = (".net.obs.so", ".net-staging.obs.so")
 
 
 def _ensure_env_file(
@@ -217,8 +217,10 @@ def _allowed_hosts_for(provider: str) -> str:
     """Allowed-hosts list for a fresh .env, adding the netmesh MagicDNS suffix
     for either netmesh transport (served requests arrive with a netmesh Host)."""
     hosts = [h for h in _DEFAULT_ALLOWED_HOSTS.split(",") if h]
-    if provider in ("netmesh", "netmesh-tsnet") and NETMESH_ALLOWED_SUFFIX not in hosts:
-        hosts.append(NETMESH_ALLOWED_SUFFIX)
+    if provider in ("netmesh", "netmesh-tsnet"):
+        for suffix in NETMESH_ALLOWED_SUFFIXES:
+            if suffix not in hosts:
+                hosts.append(suffix)
     return ",".join(hosts)
 
 
@@ -236,8 +238,12 @@ def _tailnet_provider_updates(path: Path, provider: str) -> dict[str, str]:
             ALLOWED_HOSTS_ENV_KEY, _DEFAULT_ALLOWED_HOSTS
         )
         host_list = [h.strip() for h in hosts.split(",") if h.strip()]
-        if NETMESH_ALLOWED_SUFFIX not in host_list:
-            host_list.append(NETMESH_ALLOWED_SUFFIX)
+        changed = False
+        for suffix in NETMESH_ALLOWED_SUFFIXES:
+            if suffix not in host_list:
+                host_list.append(suffix)
+                changed = True
+        if changed:
             updates[ALLOWED_HOSTS_ENV_KEY] = ",".join(host_list)
     return updates
 

--- a/openbase_coder_cli/cli/tailnet.py
+++ b/openbase_coder_cli/cli/tailnet.py
@@ -21,7 +21,11 @@ from openbase_coder_cli.services import tailscale_provider as tp
 
 PROVIDER_ENV_KEY = "OPENBASE_CODER_CLI_TAILSCALE_PROVIDER"
 ALLOWED_HOSTS_ENV_KEY = "OPENBASE_CODER_CLI_ALLOWED_HOSTS"
-NETMESH_ALLOWED_SUFFIX = ".net.obs.so"
+# Both netmesh MagicDNS domains: prod and the isolated staging control plane.
+# A staging-cloud install serves hosts under .net-staging.obs.so; listing only
+# the prod suffix made Django reject every phone request with 400 (field test
+# 2026-09-12), wedging pairing at "waiting for backend".
+NETMESH_ALLOWED_SUFFIXES = (".net.obs.so", ".net-staging.obs.so")
 
 # Pre-integration LaunchAgent label for tunneld; superseded by the managed
 # openbase-tunneld service, cleaned up on any provider switch.
@@ -123,8 +127,9 @@ def _apply_provider(name: str, *, push_cloud: bool) -> None:
         existing = env_file_values(path)
         hosts = existing.get(ALLOWED_HOSTS_ENV_KEY, "localhost,127.0.0.1,.ts.net")
         host_list = [h.strip() for h in hosts.split(",") if h.strip()]
-        if NETMESH_ALLOWED_SUFFIX not in host_list:
-            host_list.append(NETMESH_ALLOWED_SUFFIX)
+        for suffix in NETMESH_ALLOWED_SUFFIXES:
+            if suffix not in host_list:
+                host_list.append(suffix)
             values[ALLOWED_HOSTS_ENV_KEY] = ",".join(host_list)
         # Both netmesh transports MUST enroll under the same node name: peers
         # store this machine's MagicDNS name (phone backend host, syncthing

--- a/openbase_coder_cli/livekit_agent/livekit.py
+++ b/openbase_coder_cli/livekit_agent/livekit.py
@@ -1046,6 +1046,25 @@ async def livekit_agent(ctx: JobContext):
         await voice_router.close()
 
     ctx.add_shutdown_callback(close_announcer_queue)
+
+    # Surface stalled agent turns during the call — e.g. a spawned sub-agent
+    # blocked on a macOS permission dialog on the user's computer (field-test
+    # finding FT-9, 2026-09-12). Runs session-wide so it covers the dispatcher
+    # and any fire-and-forgotten sub-agent alike.
+    from . import stall_diagnostics
+
+    stall_task = asyncio.create_task(
+        stall_diagnostics.stall_watch_loop(
+            is_call_active=lambda: ctx.room.connection_state
+            == rtc.ConnectionState.CONN_CONNECTED
+        ),
+        name="openbase-stall-watch-loop",
+    )
+
+    async def _cancel_stall_watch():
+        stall_task.cancel()
+
+    ctx.add_shutdown_callback(_cancel_stall_watch)
     logger.info("LiveKit AgentSession started")
 
 

--- a/openbase_coder_cli/livekit_agent/stall_diagnostics.py
+++ b/openbase_coder_cli/livekit_agent/stall_diagnostics.py
@@ -1,0 +1,396 @@
+"""Diagnose why an in-flight Super Agents turn has stalled.
+
+Born from field-test finding FT-9 (2026-09-12): a dispatcher turn ran
+``mkdir ~/Desktop/...`` on a fresh install and hung for 6.5 minutes on the
+macOS TCC consent dialog ("python3.12 would like to access files in your
+Desktop folder") with no timeout, no error, and nothing surfaced to the
+phone. The caller (see ``super_agents_client``) races the turn wait against
+this module's diagnosis and speaks an actionable hint when a blocking GUI
+dialog is the likely cause.
+
+Detection strategy, in order of strength:
+
+1. **Dialog-presenter process recency.** macOS TCC consent dialogs are
+   rendered by ``UserNotificationCenter``; authentication sheets by
+   ``SecurityAgent``. Both are spawned on demand, so a presenter process
+   whose *start time falls inside the current turn* is strong evidence a
+   consent dialog appeared while the turn was running. (The process lingers
+   after dismissal, so recency — not mere existence — is the signal; and a
+   dismissed dialog unblocks the turn anyway, ending the stall.) This needs
+   no TCC permission of its own: it is plain ``pgrep``/``ps``.
+2. **In-flight tool call.** The Super Agents session log
+   (``~/.local/share/super-agents-*/logs/<thread>.log``) records tool_use
+   entries as JSON lines; the last Bash/tool invocation without a
+   subsequent result is what the turn is stuck on, and names the command in
+   the spoken hint.
+
+A window-server probe (CGWindowList owner scan) would be higher precision
+for "a dialog is on screen right now"; it is intentionally left as a
+follow-up — this module's interface (``diagnose``) is where it would slot
+in.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import logging
+import subprocess
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Processes macOS spawns to present consent/auth dialogs.
+DIALOG_PRESENTERS = ("UserNotificationCenter", "SecurityAgent")
+
+_PS_TIME_FORMAT = "%a %b %d %H:%M:%S %Y"  # `ps -o lstart=` output
+
+
+@dataclass
+class StallDiagnosis:
+    elapsed_seconds: float
+    blocking_dialog_process: str | None
+    in_flight_tool: str | None
+    in_flight_command: str | None
+
+    @property
+    def likely_blocked_on_dialog(self) -> bool:
+        return self.blocking_dialog_process is not None
+
+    def spoken_hint(self) -> str:
+        minutes = max(1, round(self.elapsed_seconds / 60))
+        doing = ""
+        if self.in_flight_command:
+            doing = f" while running {_speakable_command(self.in_flight_command)}"
+        elif self.in_flight_tool:
+            doing = f" while using {self.in_flight_tool}"
+        if self.likely_blocked_on_dialog:
+            return (
+                f"Heads up — your agent has been waiting{doing} for about "
+                f"{minutes} minute{'s' if minutes != 1 else ''}, and a "
+                "permission dialog appears to be open on your computer. It "
+                "may need you to click Allow."
+            )
+        return (
+            f"Your agent is still working{doing} — about "
+            f"{minutes} minute{'s' if minutes != 1 else ''} so far."
+        )
+
+    def packet_payload(self) -> dict:
+        """Forward-compatible payload for a voice-lifecycle packet so the
+        mobile apps can render this visually (planned follow-up)."""
+        return {
+            "event": "turn_stall_diagnosed",
+            "elapsed_seconds": round(self.elapsed_seconds, 1),
+            "blocking_dialog_process": self.blocking_dialog_process,
+            "in_flight_tool": self.in_flight_tool,
+            "in_flight_command_excerpt": (self.in_flight_command or "")[:120],
+        }
+
+
+def _speakable_command(command: str) -> str:
+    """First token of the command, cleaned for TTS."""
+    token = command.strip().split()[0] if command.strip() else "a command"
+    return f"the {Path(token).name} command"
+
+
+def dialog_presenter_started_after(since: _dt.datetime) -> str | None:
+    """Name of a dialog-presenter process that started after ``since``.
+
+    A TCC/auth dialog appearing mid-turn spawns its presenter; a presenter
+    younger than the turn is therefore a strong blocked-on-dialog signal.
+    """
+    for name in DIALOG_PRESENTERS:
+        try:
+            pids = subprocess.run(
+                ["pgrep", "-x", name],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            ).stdout.split()
+            for pid in pids:
+                lstart = subprocess.run(
+                    ["ps", "-o", "lstart=", "-p", pid],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                ).stdout.strip()
+                if not lstart:
+                    continue
+                started = _dt.datetime.strptime(lstart, _PS_TIME_FORMAT)
+                if started >= since:
+                    return name
+        except (OSError, subprocess.SubprocessError, ValueError):
+            continue
+    return None
+
+
+def _session_log_path(thread_id: str) -> Path | None:
+    base = Path.home() / ".local" / "share"
+    try:
+        candidates = sorted(base.glob(f"super-agents-*/logs/{thread_id}.log"))
+    except OSError:
+        return None
+    return candidates[-1] if candidates else None
+
+
+def in_flight_tool_call(thread_id: str) -> tuple[str | None, str | None]:
+    """(tool_name, command_excerpt) of the last unresolved tool call.
+
+    The session log appends one JSON object per line; a ``tool_use`` content
+    block without a later ``tool_result`` for the same id is still running.
+    """
+    path = _session_log_path(thread_id)
+    if path is None:
+        return None, None
+    try:
+        # The log can be large; the unresolved call is near the end.
+        tail = path.read_bytes()[-65536:].decode("utf-8", errors="replace")
+    except OSError:
+        return None, None
+    pending: dict[str, tuple[str, str]] = {}
+    for line in tail.splitlines():
+        brace = line.find("{")
+        if brace < 0:
+            continue
+        try:
+            entry = json.loads(line[brace:])
+        except json.JSONDecodeError:
+            continue
+        for block in entry.get("content") or []:
+            if not isinstance(block, dict):
+                continue
+            if block.get("name") and block.get("id"):
+                command = ""
+                if isinstance(block.get("input"), dict):
+                    command = str(block["input"].get("command", ""))
+                pending[block["id"]] = (block["name"], command)
+            if block.get("tool_use_id"):
+                pending.pop(block["tool_use_id"], None)
+    if not pending:
+        return None, None
+    name, command = next(reversed(pending.values()))
+    return name, (command or None)
+
+
+def diagnose(
+    *,
+    turn_started_at: _dt.datetime,
+    elapsed_seconds: float,
+    thread_id: str,
+) -> StallDiagnosis:
+    tool, command = in_flight_tool_call(thread_id)
+    return StallDiagnosis(
+        elapsed_seconds=elapsed_seconds,
+        blocking_dialog_process=dialog_presenter_started_after(turn_started_at),
+        in_flight_tool=tool,
+        in_flight_command=command,
+    )
+
+
+_SQLITE_TS_FORMATS = (
+    "%Y-%m-%dT%H:%M:%S.%f%z",
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%d %H:%M:%S.%f",
+    "%Y-%m-%d %H:%M:%S",
+)
+
+
+def _parse_sqlite_ts(value: str) -> _dt.datetime | None:
+    value = (value or "").replace("Z", "+00:00")
+    for fmt in _SQLITE_TS_FORMATS:
+        try:
+            parsed = _dt.datetime.strptime(value, fmt)
+            return parsed.astimezone().replace(tzinfo=None)
+        except ValueError:
+            continue
+    return None
+
+
+# A spawned agent process blocked at startup on a macOS permission dialog
+# (TCC folder access, auth sheet) has its control plane time out during
+# initialization, so the turn ends with this signature rather than a
+# filesystem error. Confirmed twice in the 2026-09-12 field test (agents
+# "Grace" on Documents and "Mary" on Downloads). This is the reliable,
+# reproducible signal — unlike racing the transient dialog or the long-lived,
+# reused UserNotificationCenter presenter process, both of which live testing
+# showed to be unreliable.
+CONTROL_INIT_TIMEOUT_SIGNATURE = "control request timeout: initialize"
+
+
+@dataclass
+class BlockedTurn:
+    session_id: str
+    session_name: str
+    agent_name: str | None
+    turn_id: str
+    last_error: str
+
+    def spoken_hint(self) -> str:
+        who = self.agent_name if self.agent_name else "an agent"
+        if who.lower() == "dispatcher":
+            who = "an agent"
+        return (
+            f"Heads up — {who} couldn't start on your computer. It may be "
+            "showing a permission dialog that needs your approval; check your "
+            "Mac and click Allow, then ask me to try again."
+        )
+
+    def packet_payload(self) -> dict:
+        """Forward-compatible payload for a voice-lifecycle packet so the
+        mobile apps can render this visually (planned follow-up)."""
+        return {
+            "event": "agent_turn_blocked",
+            "session_name": self.session_name,
+            "agent_name": self.agent_name,
+            "turn_id": self.turn_id,
+            "reason": "likely_permission_dialog",
+        }
+
+
+def scan_blocked_turns(
+    *,
+    since: _dt.datetime | None = None,
+    now: _dt.datetime | None = None,
+    state_db_path: Path | None = None,
+) -> list[BlockedTurn]:
+    """Find agent turns that recently failed with the blocked-at-init signature.
+
+    Covers the dispatcher AND fire-and-forgotten sub-agents uniformly, since
+    both are rows in the shared Super Agents store. ``since`` bounds recency so
+    only fresh failures (this call) are surfaced; callers additionally dedupe
+    by ``turn_id``.
+    """
+    import sqlite3
+
+    if state_db_path is None:
+        try:
+            from openbase_coder_cli.thread_sync.thread_sync_common import (
+                super_agents_state_db_path,
+            )
+
+            state_db_path = super_agents_state_db_path()
+        except Exception:  # noqa: BLE001 - resolution is best-effort
+            return []
+    if not Path(state_db_path).exists():
+        return []
+    now = now or _dt.datetime.now()
+    try:
+        conn = sqlite3.connect(f"file:{state_db_path}?mode=ro", uri=True, timeout=5)
+    except sqlite3.Error:
+        return []
+    try:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT t.id AS turn_id, t.last_error, "
+            "COALESCE(t.finished_at, t.updated_at) AS ended_at, "
+            "s.id AS session_id, s.name, s.agent_name "
+            "FROM turns t JOIN sessions s ON s.id = t.session_id "
+            "WHERE t.status = 'failed' AND t.last_error IS NOT NULL"
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    finally:
+        conn.close()
+    results: list[BlockedTurn] = []
+    for row in rows:
+        error = row["last_error"] or ""
+        if CONTROL_INIT_TIMEOUT_SIGNATURE not in error.lower():
+            continue
+        if since is not None:
+            ended = _parse_sqlite_ts(row["ended_at"])
+            if ended is not None and ended < since:
+                continue
+        results.append(
+            BlockedTurn(
+                session_id=row["session_id"],
+                session_name=row["name"],
+                agent_name=row["agent_name"],
+                turn_id=row["turn_id"],
+                last_error=error,
+            )
+        )
+    return results
+
+
+async def stall_watch_loop(
+    *,
+    poll_seconds: float = 15.0,
+    is_call_active=None,
+) -> None:
+    """Background poller: surface blocked agent turns during a live call.
+
+    Runs for the lifetime of a LiveKit voice session. Every ``poll_seconds``
+    it looks for agent turns (dispatcher OR spawned sub-agent) that just failed
+    with the blocked-at-init signature — the reliable signal that a process is
+    stuck behind a macOS permission dialog on the user's computer (field-test
+    finding FT-9). Each such turn is announced once, so the person on the phone
+    learns their Mac needs attention. ``is_call_active``, if given, gates
+    speaking so hints never play outside an active call.
+    """
+    import asyncio
+
+    spoken_turn_ids: set[str] = set()
+    loop = asyncio.get_running_loop()
+    # Only surface failures observed from when the watcher started, so a
+    # pre-existing stale failure doesn't get announced on a fresh call.
+    since = _dt.datetime.now()
+    while True:
+        try:
+            await asyncio.sleep(poll_seconds)
+            blocked = await loop.run_in_executor(
+                None, lambda: scan_blocked_turns(since=since)
+            )
+            for turn in blocked:
+                if turn.turn_id in spoken_turn_ids:
+                    continue
+                spoken_turn_ids.add(turn.turn_id)
+                if is_call_active is not None and not is_call_active():
+                    continue
+                delivered = await loop.run_in_executor(
+                    None, speak_via_local_api, turn.spoken_hint()
+                )
+                logger.info(
+                    "%s stage=agent_turn_blocked_hint_spoken session=%s "
+                    "agent=%s turn_id=%s delivered=%s",
+                    "dispatch_timing",
+                    turn.session_name,
+                    turn.agent_name,
+                    turn.turn_id,
+                    delivered,
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 - a diagnostic must never crash the call
+            logger.exception("stall_watch_loop iteration failed")
+
+
+def speak_via_local_api(text: str, *, agent_name: str = "Dispatcher") -> bool:
+    """Speak ``text`` through the local ``user say`` endpoint.
+
+    Reuses the product's existing announcer path so the hint plays inside
+    the live call with the standard announcer voice.
+    """
+    token_path = Path.home() / ".openbase" / "local-api-token"
+    try:
+        token = token_path.read_text().strip()
+    except OSError:
+        logger.warning("stall hint not spoken: local API token unavailable")
+        return False
+    request = urllib.request.Request(
+        "http://127.0.0.1:7999/api/user/say/",
+        data=json.dumps({"agent_name": agent_name, "text": text}).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return 200 <= response.status < 300
+    except OSError as exc:
+        logger.warning("stall hint not spoken: %s", exc)
+        return False

--- a/openbase_coder_cli/services/netmesh_companion.py
+++ b/openbase_coder_cli/services/netmesh_companion.py
@@ -16,6 +16,7 @@ companion long enough to issue control operations.
 from __future__ import annotations
 
 import json
+import os
 import re
 import secrets
 import subprocess
@@ -199,12 +200,35 @@ def netmesh_ctl_path(workspace_dir: str | Path | None = None) -> str | None:
     return str(ctl) if ctl.is_file() else None
 
 
+def _netmesh_source_checkout(workspace_dir: Path) -> Path | None:
+    """The netmesh-macos source checkout the stage script would build from.
+
+    Mirrors the candidate order in ``desktop/scripts/stage-netmesh-companion.mjs``
+    (env override, in-repo checkout, workspace sibling). Public workspace
+    clones have none of these — the stage script then downloads the signed
+    prebuilt instead of building, so no Xcode toolchain is needed.
+    """
+    env_dir = os.environ.get("OPENBASE_NETMESH_MACOS_DIR")
+    candidates = [
+        Path(env_dir) if env_dir else None,
+        workspace_dir / "desktop" / "netmesh-macos",
+        workspace_dir / "netmesh-macos",
+    ]
+    for candidate in candidates:
+        if candidate is not None and (candidate / "project.yml").is_file():
+            return candidate
+    return None
+
+
 def _missing_build_tools(workspace_dir: Path) -> list[str]:
-    """Tools required to build the companion that aren't installed.
+    """Tools required to stage the companion that aren't installed.
 
     This is the single source of truth for the netmesh (Openbase VPN) build
     prerequisites — the human docs point here rather than re-listing them.
-    ``go`` is only needed when the pinned tailscale engine hasn't been staged
+    Public checkouts (no netmesh-macos source) only need ``node``: the stage
+    script downloads the signed prebuilt companion for them. The Xcode
+    toolchain is required only when a source checkout is present to build
+    from, and ``go`` only when the pinned tailscale engine hasn't been staged
     yet (it's a gitignored ~56 MB build artifact).
     """
     import shutil
@@ -212,13 +236,16 @@ def _missing_build_tools(workspace_dir: Path) -> list[str]:
     missing: list[str] = []
     if shutil.which("node") is None:
         missing.append("node (https://nodejs.org — or `brew install node`)")
+    source_checkout = _netmesh_source_checkout(workspace_dir)
+    if source_checkout is None:
+        return missing
     if shutil.which("xcodegen") is None:
         missing.append("xcodegen (`brew install xcodegen`)")
     if shutil.which("xcodebuild") is None:
         missing.append(
             "Xcode (install from the App Store, then `xcodebuild -runFirstLaunch`)"
         )
-    vendor = workspace_dir / "netmesh-macos" / "vendor" / "tailscale-bin"
+    vendor = source_checkout / "vendor" / "tailscale-bin"
     engine_staged = (vendor / "tailscaled").exists() and (vendor / "tailscale").exists()
     if not engine_staged and shutil.which("go") is None:
         missing.append(

--- a/tests/test_netmesh_companion.py
+++ b/tests/test_netmesh_companion.py
@@ -84,6 +84,9 @@ def test_missing_build_tools_lists_absent_and_skips_go_when_staged(
     import shutil
 
     workspace = tmp_path / "ws"
+    # A netmesh-macos source checkout is present -> full toolchain required.
+    (workspace / "netmesh-macos").mkdir(parents=True)
+    (workspace / "netmesh-macos" / "project.yml").write_text("name: OpenbaseNetmesh")
     # Only xcodegen/xcodebuild present; node + go absent.
     present = {"xcodegen", "xcodebuild"}
     monkeypatch.setattr(
@@ -100,6 +103,43 @@ def test_missing_build_tools_lists_absent_and_skips_go_when_staged(
     (vendor / "tailscale").write_text("")
     missing_staged = nc._missing_build_tools(workspace)
     assert not any(m.startswith("go") for m in missing_staged)
+
+
+def test_missing_build_tools_public_clone_needs_only_node(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A public workspace clone has no netmesh-macos source; the stage script
+    downloads the signed prebuilt, so only node is required (regression:
+    setup used to demand xcodegen/Xcode/go and abort VPN provisioning)."""
+    import shutil
+
+    workspace = tmp_path / "ws"
+    monkeypatch.delenv("OPENBASE_NETMESH_MACOS_DIR", raising=False)
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    missing = nc._missing_build_tools(workspace)
+    assert [m for m in missing if m.startswith("node")]
+    assert len(missing) == 1
+
+    monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
+    assert nc._missing_build_tools(workspace) == []
+
+
+def test_missing_build_tools_env_override_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """OPENBASE_NETMESH_MACOS_DIR points at a source checkout -> build tools
+    are required again, matching stage-netmesh-companion.mjs's candidates."""
+    import shutil
+
+    workspace = tmp_path / "ws"
+    source = tmp_path / "elsewhere" / "netmesh-macos"
+    source.mkdir(parents=True)
+    (source / "project.yml").write_text("name: OpenbaseNetmesh")
+    monkeypatch.setenv("OPENBASE_NETMESH_MACOS_DIR", str(source))
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    missing = nc._missing_build_tools(workspace)
+    assert any(m.startswith("xcodegen") for m in missing)
 
 
 def test_build_companion_fails_fast_with_prereq_message(

--- a/tests/test_setup_cli.py
+++ b/tests/test_setup_cli.py
@@ -918,6 +918,18 @@ def test_ensure_env_file_adds_staging_backend_without_overriding_explicit_url(
     )
 
 
+def test_allowed_hosts_include_staging_netmesh_suffix() -> None:
+    """Both netmesh MagicDNS domains must be allowed: a staging-cloud install
+    serves hosts under .net-staging.obs.so, and listing only the prod suffix
+    made Django 400 every phone request (field test 2026-09-12)."""
+    from openbase_coder_cli.cli.setup import env as setup_env
+
+    hosts = setup_env._allowed_hosts_for("netmesh").split(",")
+    assert ".net.obs.so" in hosts
+    assert ".net-staging.obs.so" in hosts
+    assert ".net-staging.obs.so" not in setup_env._allowed_hosts_for("direct")
+
+
 def test_ensure_env_file_persists_process_env_override(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/test_setup_cli.py
+++ b/tests/test_setup_cli.py
@@ -918,6 +918,29 @@ def test_ensure_env_file_adds_staging_backend_without_overriding_explicit_url(
     )
 
 
+def test_ensure_env_file_persists_process_env_override(
+    tmp_path, monkeypatch
+) -> None:
+    """An OPENBASE_CODER_CLI_WEB_BACKEND_URL exported around ./scripts/setup
+    (e.g. pointing a dev install at staging) must land in the generated .env;
+    it used to be silently dropped, leaving the install targeting prod."""
+    env_file = tmp_path / ".env"
+    monkeypatch.setenv(
+        "OPENBASE_CODER_CLI_WEB_BACKEND_URL", "https://app-staging.openbase.cloud"
+    )
+
+    setup_cli._ensure_env_file(
+        str(env_file),
+        assembly_ai_api_key="",
+        cartesia_api_key="",
+    )
+
+    assert (
+        setup_cli._env_file_values(env_file)["OPENBASE_CODER_CLI_WEB_BACKEND_URL"]
+        == "https://app-staging.openbase.cloud"
+    )
+
+
 def test_ensure_env_file_migrates_existing_env_to_shared_homes(tmp_path) -> None:
     env_file = tmp_path / ".env"
     env_file.write_text(

--- a/tests/test_stall_diagnostics.py
+++ b/tests/test_stall_diagnostics.py
@@ -1,0 +1,237 @@
+"""Tests for livekit_agent.stall_diagnostics (field-test finding FT-9)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+import pytest
+
+from openbase_coder_cli.livekit_agent import stall_diagnostics as sd
+
+
+def _write_session_log(tmp_path: Path, thread_id: str, lines: list[dict]) -> None:
+    logs = tmp_path / "super-agents-claude-code" / "logs"
+    logs.mkdir(parents=True)
+    path = logs / f"{thread_id}.log"
+    path.write_text(
+        "\n".join(f"[2026-09-12T17:20:28.080Z] {json.dumps(entry)}" for entry in lines)
+    )
+
+
+def test_in_flight_tool_call_finds_unresolved_bash(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    share = tmp_path / ".local" / "share"
+    _write_session_log(
+        share,
+        "s_abc",
+        [
+            {"content": [{"id": "t1", "name": "Bash", "input": {"command": "ls"}}]},
+            {"content": [{"tool_use_id": "t1", "type": "tool_result"}]},
+            {
+                "content": [
+                    {
+                        "id": "t2",
+                        "name": "Bash",
+                        "input": {"command": 'mkdir -p ~/Desktop/"Demo project"'},
+                    }
+                ]
+            },
+        ],
+    )
+    tool, command = sd.in_flight_tool_call("s_abc")
+    assert tool == "Bash"
+    assert command is not None and command.startswith("mkdir")
+
+
+def test_in_flight_tool_call_none_when_all_resolved(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    share = tmp_path / ".local" / "share"
+    _write_session_log(
+        share,
+        "s_done",
+        [
+            {"content": [{"id": "t1", "name": "Bash", "input": {"command": "ls"}}]},
+            {"content": [{"tool_use_id": "t1", "type": "tool_result"}]},
+        ],
+    )
+    assert sd.in_flight_tool_call("s_done") == (None, None)
+
+
+def test_in_flight_tool_call_missing_log(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert sd.in_flight_tool_call("s_missing") == (None, None)
+
+
+def test_dialog_presenter_recency(monkeypatch):
+    calls = {}
+
+    class FakeCompleted:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    def fake_run(argv, **kwargs):
+        calls.setdefault(argv[0], []).append(argv)
+        if argv[0] == "pgrep":
+            # Only UserNotificationCenter is running.
+            return FakeCompleted(
+                "123\n" if argv[-1] == "UserNotificationCenter" else ""
+            )
+        if argv[0] == "ps":
+            return FakeCompleted("Fri Sep 12 17:20:19 2026\n")
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(sd.subprocess, "run", fake_run)
+
+    turn_start_before_dialog = dt.datetime(2026, 9, 12, 17, 20, 0)
+    assert (
+        sd.dialog_presenter_started_after(turn_start_before_dialog)
+        == "UserNotificationCenter"
+    )
+
+    turn_start_after_dialog = dt.datetime(2026, 9, 12, 18, 0, 0)
+    assert sd.dialog_presenter_started_after(turn_start_after_dialog) is None
+
+
+def test_spoken_hint_blocked_names_command_and_dialog():
+    diagnosis = sd.StallDiagnosis(
+        elapsed_seconds=130,
+        blocking_dialog_process="UserNotificationCenter",
+        in_flight_tool="Bash",
+        in_flight_command='mkdir -p ~/Desktop/"Demo project"',
+    )
+    hint = diagnosis.spoken_hint()
+    assert "permission dialog" in hint
+    assert "mkdir" in hint
+    assert "2 minutes" in hint
+    assert diagnosis.packet_payload()["event"] == "turn_stall_diagnosed"
+
+
+def test_spoken_hint_soft_status_without_dialog():
+    diagnosis = sd.StallDiagnosis(
+        elapsed_seconds=200,
+        blocking_dialog_process=None,
+        in_flight_tool="Bash",
+        in_flight_command="pytest -q",
+    )
+    hint = diagnosis.spoken_hint()
+    assert "permission dialog" not in hint
+    assert "still working" in hint
+
+
+def test_speak_via_local_api_without_token(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert sd.speak_via_local_api("hello") is False
+
+
+def _make_state_db(tmp_path: Path, sessions: list[dict], turns: list[dict]) -> Path:
+    import sqlite3
+
+    db = tmp_path / "state.sqlite3"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE sessions (id text primary key, name text, agent_name text, "
+        "status text, active_turn_id text)"
+    )
+    conn.execute(
+        "CREATE TABLE turns (id text primary key, session_id text, status text, "
+        "last_error text, created_at text, updated_at text, finished_at text)"
+    )
+    for s in sessions:
+        conn.execute(
+            "INSERT INTO sessions VALUES (:id,:name,:agent_name,:status,:active_turn_id)",
+            s,
+        )
+    for t in turns:
+        conn.execute(
+            "INSERT INTO turns VALUES "
+            "(:id,:session_id,:status,:last_error,:created_at,:updated_at,:finished_at)",
+            t,
+        )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _subagent_db(tmp_path, *, last_error, ended, status="failed"):
+    return _make_state_db(
+        tmp_path,
+        sessions=[
+            {
+                "id": "s_disp",
+                "name": "dispatcher",
+                "agent_name": "Dispatcher",
+                "status": "completed",
+                "active_turn_id": None,
+            },
+            {
+                "id": "s_grace",
+                "name": "list-documents-files",
+                "agent_name": "Grace",
+                "status": "failed",
+                "active_turn_id": None,
+            },
+        ],
+        turns=[
+            {
+                "id": "t_grace",
+                "session_id": "s_grace",
+                "status": status,
+                "last_error": last_error,
+                "created_at": ended,
+                "updated_at": ended,
+                "finished_at": ended,
+            }
+        ],
+    )
+
+
+def test_scan_blocked_turns_catches_spawned_subagent(tmp_path):
+    """The key FT-9 case: a spawned sub-agent failed blocked-at-init."""
+    now = dt.datetime(2026, 9, 12, 18, 6, 0)
+    ended = (now - dt.timedelta(seconds=20)).strftime("%Y-%m-%d %H:%M:%S")
+    db = _subagent_db(
+        tmp_path, last_error="Control request timeout: initialize", ended=ended
+    )
+    blocked = sd.scan_blocked_turns(
+        since=now - dt.timedelta(minutes=5), now=now, state_db_path=db
+    )
+    assert len(blocked) == 1
+    b = blocked[0]
+    assert b.agent_name == "Grace"
+    hint = b.spoken_hint()
+    assert "Grace" in hint
+    assert "permission dialog" in hint
+    assert b.packet_payload()["event"] == "agent_turn_blocked"
+
+
+def test_scan_blocked_turns_ignores_other_errors(tmp_path):
+    now = dt.datetime(2026, 9, 12, 18, 6, 0)
+    ended = (now - dt.timedelta(seconds=20)).strftime("%Y-%m-%d %H:%M:%S")
+    db = _subagent_db(tmp_path, last_error="Some unrelated network error", ended=ended)
+    assert (
+        sd.scan_blocked_turns(
+            since=now - dt.timedelta(minutes=5), now=now, state_db_path=db
+        )
+        == []
+    )
+
+
+def test_scan_blocked_turns_respects_since_window(tmp_path):
+    now = dt.datetime(2026, 9, 12, 18, 6, 0)
+    ended = (now - dt.timedelta(minutes=30)).strftime("%Y-%m-%d %H:%M:%S")
+    db = _subagent_db(
+        tmp_path, last_error="Control request timeout: initialize", ended=ended
+    )
+    # A failure from before the watcher started is not surfaced.
+    assert (
+        sd.scan_blocked_turns(
+            since=now - dt.timedelta(minutes=5), now=now, state_db_path=db
+        )
+        == []
+    )
+
+
+def test_scan_blocked_turns_missing_db_returns_empty(tmp_path):
+    assert sd.scan_blocked_turns(state_db_path=tmp_path / "nope.sqlite3") == []


### PR DESCRIPTION
Two findings from the 2026-09-12 field test (developer-install pathway, staging branch, clean-room Tart VM). Both reproduced on a fresh public clone of the workspace.

**FT-1 — netmesh transport unusable on public clones without Xcode.** `./scripts/setup --tailnet-provider netmesh` fails the companion build-tools check demanding xcodegen/Xcode/go, even though public checkouts (no `netmesh-macos` source) are exactly the case where `desktop/scripts/stage-netmesh-companion.mjs` downloads the signed prebuilt and needs only `node`. `_missing_build_tools` now requires the Xcode toolchain only when a netmesh-macos source checkout is present (env override, in-repo, or workspace sibling — mirroring the stage script's candidate order).

**FT-2 — staging override silently dropped by setup.** Exporting `OPENBASE_CODER_CLI_WEB_BACKEND_URL=https://app-staging.openbase.cloud` around `./scripts/setup` did not persist into `~/.openbase/.env`, so a staging-intended dev install silently targeted production. The explicit process-env override is now persisted in both the fresh-.env and update paths (existing explicit values still win).

Verified in the VM by working around both by hand (stage scripts + manual .env append) — VPN then connects on net-staging and services come up. `tests/test_netmesh_companion.py` + `tests/test_setup_cli.py`: 103 passed.

Slack: reported in #qa (field test 2026-09-12 thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137hB7KGvgHZkbj1PN2utSb